### PR TITLE
Use quotation marks around search results explanation

### DIFF
--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -194,7 +194,7 @@ class Results extends React.Component {
   render() {
     const results = this.getList(this.state.searchResults);
     let resultsNumberSuggestion = (results.length === 0) ?
-      'No items were found' : `About ${this.props.amount} results for ${this.props.searchKeyword}`;
+      'No items were found' : `Found about ${this.props.amount.toLocaleString()} results for "${this.props.searchKeyword}"`;
     if (this.props.selectedFacet !== undefined && this.props.selectedFacet !== ''){
       resultsNumberSuggestion += ` in ${this.props.selectedFacet.replace('_', ' ')}`;
     }


### PR DESCRIPTION
Notice that "Found" is present, that the thousands separator is present, and that there are quotation marks around the search string.
<img width="365" alt="screen shot 2018-11-15 at 12 37 24 pm" src="https://user-images.githubusercontent.com/1825103/48570825-41885f80-e8d3-11e8-8f4e-a6ea9a582b11.png">
