### PR TITLE
Change aria-label for search field WWW-501

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Updated
 - Note: we'll add all changes for Sprint 24 in this section and will delete this line on Nov 29, 2018.
 - Removing role and aria-atomic from area that announces the search results
+- Changing the aria-label for the search field
 
 ### v0.3.10
 #### Updated

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -278,7 +278,7 @@ class App extends React.Component {
           <div id="gs-operations" className="gs-operations">
             <div id="gs-searchField" className="gs-searchField">
               <div id="gs-inputField-wrapper" className="gs-inputField-wrapper">
-                <label htmlFor="gs-inputField" className="visuallyHidden">Enter Search Terms</label>
+                <label htmlFor="gs-inputField" className="visuallyHidden">Search NYPL.org</label>
                 <InputField
                   id="gs-inputField"
                   className="gs-inputField"
@@ -287,7 +287,7 @@ class App extends React.Component {
                   value={inputValue}
                   onKeyPress={this.triggerSubmit}
                   onChange={this.inputChange}
-                  label="Enter Search Terms"
+                  label="Search NYPL.org"
                 />
               </div>
               <SearchButton


### PR DESCRIPTION
You can see the aria-label is now "Search NYPL.org".
<img width="860" alt="screen shot 2018-11-16 at 1 15 21 pm" src="https://user-images.githubusercontent.com/1825103/48639587-fb4e0180-e9a1-11e8-9e30-c03c7d4f2dde.png">
