### PR TITLE
Show aria-live before search term is entered

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -244,9 +244,6 @@ class App extends React.Component {
    * @return {object} object
    */
   renderResults(searchKeyword, searchResultsArray, searchResultsLength) {
-    if (!searchKeyword) {
-      return null;
-    }
     return (
       <Results
         amount={searchResultsLength}

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -193,8 +193,13 @@ class Results extends React.Component {
 
   render() {
     const results = this.getList(this.state.searchResults);
-    let resultsNumberSuggestion = (results.length === 0) ?
-      'No items were found' : `Found about ${this.props.amount.toLocaleString()} results for "${this.props.searchKeyword}"`;
+    let resultsNumberSuggestion = '';
+    if (this.props.searchKeyword === '') {
+      resultsNumberSuggestion = '';
+    } else {
+      resultsNumberSuggestion = (results.length === 0) ?
+        'No items were found' : `Found about ${this.props.amount.toLocaleString()} results for "${this.props.searchKeyword}"`;
+    }
     if (this.props.selectedFacet !== undefined && this.props.selectedFacet !== ''){
       resultsNumberSuggestion += ` in ${this.props.selectedFacet.replace('_', ' ')}`;
     }


### PR DESCRIPTION
Prior to this PR, the aria-live region would be visible on the page once the first search results loaded.  When the search is refined, then the results would be announced.

We want the results for the first search to be announced too, so we must have the aria-live region on the page even before the user enters their first search term.