### PR TITLE
Adjust CSS for returnLink

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -9,7 +9,6 @@ import Footer from '@nypl/dgx-react-footer';
 import Results from '../Results/Results.jsx';
 import InputField from '../InputField/InputField.jsx';
 import SearchButton from '../SearchButton/SearchButton.jsx';
-import ReturnLink from '../ReturnLink/ReturnLink.jsx';
 
 // Import alt components
 import Store from '../../stores/Store.js';
@@ -293,7 +292,6 @@ class App extends React.Component {
             </div>
           </div>
           {this.state.resultsComponentData}
-          <ReturnLink linkRoot="/search/apachesolr_search/" inputValue={inputValue} />
         </div>
 
         <Footer id="footer" className="footer" />

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -11,6 +11,7 @@ import ResultsItem from '../ResultsItem/ResultsItem.jsx';
 import { DivideLineIcon } from 'dgx-svg-icons';
 import { PaginationButton } from 'dgx-react-buttons';
 import TabItem from '../TabItem/TabItem.jsx';
+import ReturnLink from '../ReturnLink/ReturnLink.jsx';
 
 // Import libraries
 import { contains as _contains, map as _map } from 'underscore';
@@ -222,6 +223,7 @@ class Results extends React.Component {
   render() {
     const results = this.getList(this.state.searchResults);
     let resultsNumberSuggestion = '';
+    const inputValue = this.props.searchKeyword || '';
     if (this.props.searchKeyword === '') {
       resultsNumberSuggestion = '';
     } else {
@@ -267,6 +269,7 @@ class Results extends React.Component {
               {results}
             </ol>
             {results.length % 10 == 0 && this.renderSeeMoreButton(Math.min(this.props.amount - results.length, 10))}
+            <ReturnLink linkRoot="/search/apachesolr_search/" inputValue={inputValue} />
           </div>
         }
       </div>

--- a/src/app/components/ReturnLink/ReturnLink.jsx
+++ b/src/app/components/ReturnLink/ReturnLink.jsx
@@ -5,7 +5,7 @@ const ReturnLink = ({
   linkRoot,
   inputValue,
 }) => (
-  <div className="returnLink">
+  <div className="returnLink gs-results-paginationButton-wrapper">
     <a
       href={`${linkRoot}${inputValue}`}
     >

--- a/src/client/styles/components/_ReturnLink.scss
+++ b/src/client/styles/components/_ReturnLink.scss
@@ -4,8 +4,8 @@
   font-size: 0.8em;
   text-align: center;
   display: block;
-  margin: -45px 0 45px;
-  padding: 0 14px;
+  position:relative;
+  top:-65px;
 
   a {
     color: $SEARCH_BLUE;
@@ -13,30 +13,5 @@
 
   span {
     color: $COOLGRAY_COLOR;
-  }
-
-  @include layout-at(7, $tablet-portrait) {
-    padding: 0 36px;
-  }
-
-  @include layout-at(8, $tablet-landscape) {
-    @include grid-span(7, 1);;
-
-    margin: -45px 0 45px;
-    padding: 0;
-
-    div {
-      float: right;
-      margin: 0 27px -27px 0;
-    }
-  }
-
-  @include layout-at(8, $desktop) {
-    div {
-      margin: 0;
-      float: right;
-      position: relative;
-      top: -4px;
-    }
   }
 }


### PR DESCRIPTION
The return link is now overlaying the button or the filters.
It isn't showing until after the first search.
Now it is centered the same way as the button for all screen sizes.
<img width="452" alt="screen shot 2018-11-27 at 8 25 15 am" src="https://user-images.githubusercontent.com/1825103/49084625-00227900-f21e-11e8-9bcb-bde5fb54055c.png">
