### PR TITLE
Usability bug when selecting a filter WWW-526

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -26,7 +26,11 @@ history.listen(location => {
     action,
     pathname,
   } = location;
-  const searchKeyword = (pathname.split('/')[2]) ? pathname.split('/')[2] : '';
+
+  const keywordFromSearchBox = document.getElementById('gs-inputField').value;
+  const keywordFromPath = (pathname.split('/')[2]) ? pathname.split('/')[2] : '';
+  const searchKeyword = keywordFromSearchBox !== '' ? keywordFromSearchBox : keywordFromPath;
+
   const searchFacet = (pathname.split('/')[3]) ? pathname.split('/')[3] : '';
   const resultsStart = 0;
 


### PR DESCRIPTION
Now a user can enter a search term, click a filter, and see results.

They do not need to click the search button.