### PR TITLE
Link to old search WWW-491

### DIFF
--- a/src/client/styles/components/_ReturnLink.scss
+++ b/src/client/styles/components/_ReturnLink.scss
@@ -1,11 +1,11 @@
 .returnLink {
-  @include Kievit-Medium;
+  @include Kievit-Book;
 
-  font-size: 0.8em;
+  font-size: 1em;
   text-align: center;
   display: block;
-  position:relative;
-  top:-65px;
+  position: relative;
+  top: -65px;
 
   a {
     color: $SEARCH_BLUE;


### PR DESCRIPTION
New format of the "return to old search" link:
<img width="405" alt="screen shot 2018-11-28 at 9 57 16 pm" src="https://user-images.githubusercontent.com/1825103/49196341-9a86d780-f358-11e8-906e-9d5c3f880187.png">
