### PR TITLE
Resolve http-https errors with search results WWW-523

### DIFF
--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -103,7 +103,7 @@ class Results extends React.Component {
    */
   transformHttpsToHttp(link){
     const transformationRequired = (link.includes('//menus.nypl') || link.includes('//exhibitions.nypl'));
-    if (link != '' && transformationRequired) {
+    if (link && transformationRequired) {
       return link.replace('https:', 'http:')
     } else {
       return link

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -96,6 +96,20 @@ class Results extends React.Component {
     }
   }
 
+  /**
+   * transformHttpsToHttp(link)
+   * The function converts certain NYPL subdomains to http
+   * to prevent an error when that site does not have SSL enabled.
+   */
+  transformHttpsToHttp(link){
+    const transformationRequired = (link.includes('//menus.nypl') || link.includes('//exhibitions.nypl'));
+    if (link != '' && transformationRequired) {
+      return link.replace('https:', 'http:')
+    } else {
+      return link
+    }
+  }
+
 
   /**
    * getList(itemsArray)
@@ -112,7 +126,7 @@ class Results extends React.Component {
         index={index}
         ref={`result-${index}`}
         title={item.title}
-        link={item.link}
+        link={this.transformHttpsToHttp(item.link)}
         snippet={this.parseSnippet(item.snippet)}
         thumbnailSrc={item.thumbnailSrc}
         label={item.label}


### PR DESCRIPTION
Links with "https://exhibitions.nypl" and "https://menus.nypl" are now converted to http as seen in this screenshot:
<img width="891" alt="screen shot 2018-11-29 at 8 07 13 am" src="https://user-images.githubusercontent.com/1825103/49225931-49580180-f3b3-11e8-9bae-e05e080c0fac.png">
