### PR TITLE
Align filter display names with Google CSE dashboard WWW-533

### DIFF
--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -230,7 +230,15 @@ class Results extends React.Component {
         'No items were found' : `Found about ${this.props.amount.toLocaleString()} results for "${this.props.searchKeyword}"`;
     }
     if (this.props.selectedFacet !== undefined && this.props.selectedFacet !== ''){
-      resultsNumberSuggestion += ` in ${this.props.selectedFacet.replace('_', ' ')}`;
+      const tabArray = this.props.tabs;
+      const selectedFacet = this.props.selectedFacet
+      var selectedTabName = '';
+      tabArray.forEach(function(tab) {
+        if (tab['label'] === selectedFacet){
+          selectedTabName = tab['resultSummarydisplayName'];
+        }
+      });
+      resultsNumberSuggestion += ` in ${selectedTabName}`;
     }
     const resultMessageClass = (results.length === 0) ?
       'noResultMessage' : `${this.props.className}-length`;

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -231,10 +231,9 @@ class Results extends React.Component {
     }
     if (this.props.selectedFacet !== undefined && this.props.selectedFacet !== ''){
       const tabArray = this.props.tabs;
-      const selectedFacet = this.props.selectedFacet
       var selectedTabName = '';
-      tabArray.forEach(function(tab) {
-        if (tab['label'] === selectedFacet){
+      tabArray.forEach((tab) => {
+        if (tab['label'] === this.props.selectedFacet){
           selectedTabName = tab['resultSummarydisplayName'];
         }
       });

--- a/src/app/stores/Store.js
+++ b/src/app/stores/Store.js
@@ -1,4 +1,5 @@
 import Actions from '../actions/Actions.js';
+import { filterNames } from '../utils/FilterNames.js';
 import alt from 'dgx-alt-center';
 
 class SearchStore {
@@ -23,54 +24,7 @@ class SearchStore {
       this.selectedFacet = '';
       this.resultsStart = 0;
       this.resultsIncrement = 10;
-      this.searchFacets = [
-        {
-          anchor: 'All Results',
-          value: '',
-          label: 'all_results',
-        },
-        {
-          anchor: 'Articles',
-          value: 'articles_databases',
-          label: 'articles_databases',
-        },
-        {
-          anchor: 'Research Guides',
-          value: 'research_guides',
-          label: 'research_guides',
-        },
-        {
-          anchor: 'Events & Classes',
-          value: 'events_classes',
-          label: 'events_classes',
-        },
-        {
-          anchor: 'Exhibitions',
-          value: 'exhibitions',
-          label: 'exhibitions',
-        },
-        {
-          anchor: 'Blog Posts',
-          value: 'blog_posts',
-          label: 'blog_posts',
-        },
-        {
-          anchor: 'Audio & Visual',
-          value: 'audio_video',
-          label: 'audio_video',
-        },
-        {
-          anchor: 'Help Articles',
-          value: 'help_articles',
-          label: 'help_articles',
-        },
-        {
-          anchor: 'Locations',
-          value: 'locations',
-          label: 'locations',
-        }
-       
-      ];
+      this.searchFacets = filterNames;
       this.queriesForGA = {
         searchedFrom: '',
         timestamp: '',

--- a/src/app/utils/FilterNames.js
+++ b/src/app/utils/FilterNames.js
@@ -1,0 +1,58 @@
+const filterNames = [
+  {
+    anchor: 'All',
+    value: '',
+    label: 'all_results',
+    resultSummarydisplayName: '',
+  },
+  {
+    anchor: 'Databases',
+    value: 'articles_databases',
+    label: 'articles_databases',
+    resultSummarydisplayName: 'databases',
+  },
+  {
+    anchor: 'Research Guides',
+    value: 'research_guides',
+    label: 'research_guides',
+    resultSummarydisplayName: 'research guides',
+  },
+  {
+    anchor: 'Events',
+    value: 'events_classes',
+    label: 'events_classes',
+    resultSummarydisplayName: 'events',
+  },
+  {
+    anchor: 'Exhibitions',
+    value: 'exhibitions',
+    label: 'exhibitions',
+    resultSummarydisplayName: 'exhibitions',
+  },
+  {
+    anchor: 'Blogs',
+    value: 'blog_posts',
+    label: 'blog_posts',
+    resultSummarydisplayName: 'blogs',
+  },
+  {
+    anchor: 'Audio/Video',
+    value: 'audio_video',
+    label: 'audio_video',
+    resultSummarydisplayName: 'audio/video',
+  },
+  {
+    anchor: 'FAQs',
+    value: 'help_articles',
+    label: 'help_articles',
+    resultSummarydisplayName: 'FAQs',
+  },
+  {
+    anchor: 'Locations',
+    value: 'locations',
+    label: 'locations',
+    resultSummarydisplayName: 'locations',
+  }
+]
+
+export { filterNames };

--- a/src/app/utils/SearchModel.js
+++ b/src/app/utils/SearchModel.js
@@ -1,3 +1,5 @@
+import { filterNames } from './FilterNames.js';
+
 // Import libraries
 import {
   map as _map,
@@ -36,54 +38,10 @@ const fetchResultLength = (data) => {
  *
  * @return {Array}
  */
-const fetchSearchFacetsList = () =>
-      [
-        {
-          anchor: 'All Results',
-          value: '',
-          label: 'all_results',
-        },
-        {
-          anchor: 'Articles',
-          value: 'articles_databases',
-          label: 'articles_databases',
-        },
-        {
-          anchor: 'Research Guides',
-          value: 'research_guides',
-          label: 'research_guides',
-        },
-        {
-          anchor: 'Events & Classes',
-          value: 'events_classes',
-          label: 'events_classes',
-        },
-        {
-          anchor: 'Exhibitions',
-          value: 'exhibitions',
-          label: 'exhibitions',
-        },
-        {
-          anchor: 'Blog Posts',
-          value: 'blog_posts',
-          label: 'blog_posts',
-        },
-        {
-          anchor: 'Audio & Visual',
-          value: 'audio_video',
-          label: 'audio_video',
-        },
-        {
-          anchor: 'Help Articles',
-          value: 'help_articles',
-          label: 'help_articles',
-        },
-        {
-          anchor: 'Locations',
-          value: 'locations',
-          label: 'locations',
-        }
-      ]
+const fetchSearchFacetsList = () => {
+  return filterNames;
+}
+
 /**
  * extractSearchElements(requestCombo)
  * The function extracts the two searchElements from a searchRequest.

--- a/test/SearchModelTestExampleData.js
+++ b/test/SearchModelTestExampleData.js
@@ -1,3 +1,5 @@
+import { filterNames } from '../src/app/utils/FilterNames.js';
+
 const testData = {
   noItem: {
     items: [
@@ -75,51 +77,5 @@ const matchedResults = {
   ],
 };
 
-const presetFacets = [
-        {
-          anchor: 'All Results',
-          value: '',
-          label: 'all_results',
-        },
-        {
-          anchor: 'Articles',
-          value: 'articles_databases',
-          label: 'articles_databases',
-        },
-        {
-          anchor: 'Research Guides',
-          value: 'research_guides',
-          label: 'research_guides',
-        },
-        {
-          anchor: 'Events & Classes',
-          value: 'events_classes',
-          label: 'events_classes',
-        },
-        {
-          anchor: 'Exhibitions',
-          value: 'exhibitions',
-          label: 'exhibitions',
-        },
-        {
-          anchor: 'Blog Posts',
-          value: 'blog_posts',
-          label: 'blog_posts',
-        },
-        {
-          anchor: 'Audio & Visual',
-          value: 'audio_video',
-          label: 'audio_video',
-        },
-        {
-          anchor: 'Help Articles',
-          value: 'help_articles',
-          label: 'help_articles',
-        },
-        {
-          anchor: 'Locations',
-          value: 'locations',
-          label: 'locations',
-        }
-        ]
+const presetFacets = filterNames;
 export { testData, matchedResults, presetFacets };


### PR DESCRIPTION
The tag in Google is "events_classes".  We are able to give it a display name of "events" in the search results summary in red and "Events" in the label of the button:
![screen shot 2018-11-29 at 9 57 57 am](https://user-images.githubusercontent.com/1825103/49230271-45c97800-f3bd-11e8-954a-876049bde829.png)
