### PR TITLE
Improve margin for link to old search WWW-499

### DIFF
--- a/src/client/styles/components/_PaginationButton.scss
+++ b/src/client/styles/components/_PaginationButton.scss
@@ -2,7 +2,7 @@
   &-paginationButton {
     &-wrapper {
       display: block;
-      margin: 45px 0 72px 0;
+      margin: 45px 0 0 0;
       text-align: center;
 
       @include layout-at(8, $tablet-landscape) {

--- a/src/client/styles/components/_ReturnLink.scss
+++ b/src/client/styles/components/_ReturnLink.scss
@@ -4,8 +4,7 @@
   font-size: 1em;
   text-align: center;
   display: block;
-  position: relative;
-  top: -65px;
+  margin: 50px 0px 50px 0px;
 
   a {
     color: $SEARCH_BLUE;


### PR DESCRIPTION
# Before these changes:
The "return to old search" link was overlapping the last search results when the "view more" button wasn't present.
![screen shot 2018-12-04 at 10 33 37 am](https://user-images.githubusercontent.com/1825103/49452921-1a290200-f7b0-11e8-9414-09491e59942b.png)

# After these changes:
![screen shot 2018-12-04 at 10 28 16 am](https://user-images.githubusercontent.com/1825103/49452875-01b8e780-f7b0-11e8-9d4a-d69649e81e1b.png)
![screen shot 2018-12-04 at 10 27 59 am](https://user-images.githubusercontent.com/1825103/49452876-01b8e780-f7b0-11e8-8e57-58bdea915a4e.png)
