### PR TITLE
Result text improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changing filter values
 - Showing ARIA-live region on initial load of search page
 - Updating the syntax for better formatting codes in Results.jsx
+- Updating the texts for showing result information.
 
 ### v0.3.10
 #### Updated

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -244,7 +244,7 @@ class Results extends React.Component {
       resultsNumberSuggestion = '';
     } else {
       resultsNumberSuggestion = (results.length === 0) ?
-        'No items were found' :
+        'No results were found' :
         `Found about ${this.props.amount.toLocaleString()} results for ` +
         `"${this.props.searchKeyword}"`;
     }

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -238,8 +238,8 @@ class Results extends React.Component {
   render() {
     const results = this.getList(this.state.searchResults);
     const inputValue = this.props.searchKeyword || '';
+    const textOfResult = this.props.amount === 1 ? 'result' : 'results';
     let resultsNumberSuggestion = '';
-    let textOfResult = this.props.amount === 1 ? 'result' : 'results';
 
     if (this.props.searchKeyword === '') {
       resultsNumberSuggestion = '';

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -237,15 +237,16 @@ class Results extends React.Component {
 
   render() {
     const results = this.getList(this.state.searchResults);
-    let resultsNumberSuggestion = '';
     const inputValue = this.props.searchKeyword || '';
+    let resultsNumberSuggestion = '';
+    let textOfResult = this.props.amount === 1 ? 'result' : 'results';
 
     if (this.props.searchKeyword === '') {
       resultsNumberSuggestion = '';
     } else {
       resultsNumberSuggestion = (results.length === 0) ?
         'No results were found' :
-        `Found about ${this.props.amount.toLocaleString()} results for ` +
+        `Found about ${this.props.amount.toLocaleString()} ${textOfResult} for ` +
         `"${this.props.searchKeyword}"`;
     }
     if (this.props.selectedFacet !== undefined && this.props.selectedFacet !== '') {


### PR DESCRIPTION
This PR is for the tickets https://jira.nypl.org/browse/WWW-542 and https://jira.nypl.org/browse/WWW-538

It update the text "Results" to be either "Results" or "Result" based on how many results we get. when there's no results. It shows "No results were found" but "No items were found"

It can be tested on dev
http://nypl-global-search-development.us-east-1.elasticbeanstalk.com/search/duck/

Please search "duck" with different facets for testing.