### PR TITLE
Move role and aria-label to search container WWW-497

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 ## Changelog
 ### v0.3.12
 #### Updated
-- Note: we'll add all changes for Sprint 24 in this section and will delete this line on Nov 29, 2018.
+- Note: we'll add all changes here until the deployment around December 11th
 - Removing role and aria-atomic from area that announces the search results
 - Changing the label for the search field
 - Removing loading screen
 - Fixing JSON display bug
 - Changing filter values
 - Showing ARIA-live region on initial load of search page
+- Making a div with a role of "search" that contains search functionality & results
 
 ### v0.3.10
 #### Updated

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -267,31 +267,33 @@ class App extends React.Component {
       <div id="nyplGlobalSearchApp" className="nyplGlobalSearchApp">
         <Header navData={navConfig.current} skipNav={{ target: 'gs-mainContent' }} />
         <main id="gs-mainContent" className="gs-mainContent" tabIndex="-1">
-          <h1>NYPL.org Search <span>BETA</span></h1>
-          <div id="gs-operations" className="gs-operations">
-            <div id="gs-searchField" className="gs-searchField">
-              <div id="gs-inputField-wrapper" className="gs-inputField-wrapper">
-                <label htmlFor="gs-inputField" className="visuallyHidden">Search NYPL.org</label>
-                <InputField
-                  id="gs-inputField"
-                  className="gs-inputField"
-                  type="text"
-                  placeholder={inputPlaceholder}
-                  value={inputValue}
-                  onKeyPress={this.triggerSubmit}
-                  onChange={this.inputChange}
-                  label="NYPL Site Search"
+          <div aria-label="NYPL Site Search" role="search">
+            <h1>NYPL.org Search <span>BETA</span></h1>
+            <div id="gs-operations" className="gs-operations">
+              <div id="gs-searchField" className="gs-searchField">
+                <div id="gs-inputField-wrapper" className="gs-inputField-wrapper">
+                  <label htmlFor="gs-inputField" className="visuallyHidden">Search NYPL.org</label>
+                  <InputField
+                    id="gs-inputField"
+                    className="gs-inputField"
+                    type="text"
+                    placeholder={inputPlaceholder}
+                    value={inputValue}
+                    onKeyPress={this.triggerSubmit}
+                    onChange={this.inputChange}
+                    label="NYPL Site Search"
+                  />
+                </div>
+                <SearchButton
+                  id="gs-searchButton"
+                  className="gs-searchButton"
+                  label="SEARCH"
+                  onClick={() => this.triggerGAThenSubmit(this.state.selectedFacet)}
                 />
               </div>
-              <SearchButton
-                id="gs-searchButton"
-                className="gs-searchButton"
-                label="SEARCH"
-                onClick={() => this.triggerGAThenSubmit(this.state.selectedFacet)}
-              />
             </div>
+            {this.state.resultsComponentData}
           </div>
-          {this.state.resultsComponentData}
         </main>
         <Footer id="footer" className="footer" />
       </div>

--- a/src/app/components/InputField/InputField.jsx
+++ b/src/app/components/InputField/InputField.jsx
@@ -31,9 +31,7 @@ const InputField = ({
     onChange={onChange}
     required={isRequired}
     style={style}
-    aria-label={label}
     aria-required="true"
-    role="search"
   />
 );
 

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -262,7 +262,7 @@ class Results extends React.Component {
       'noResultMessage' : `${this.props.className}-length`;
 
     return (
-      <div aria-labelledby={`link${this.props.selectedTab}`} className={`${this.props.className}-wrapper`}>
+      <div className={`${this.props.className}-wrapper`}>
         <p
           id="search-results-summary"
           className={resultMessageClass}


### PR DESCRIPTION
In this PR, we move `role="search"` and the `aria-label` to a div which wraps the whole search area.