### PR TITLE
Update text for catalog search link

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -299,7 +299,7 @@ class App extends React.Component {
                     'Orightresult__U?lang=eng&suite=def'
                   }
                 >
-                  Find a book, movie, or music instead >
+                  Find books, music, or movies instead >
                 </a>
               </div>
             </div>

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -293,7 +293,7 @@ class App extends React.Component {
                 />
               </div>
               <div className="gs-search-catalog-link-wrapper">
-                <a
+                <a className="gs-search-catalog-link"
                   href={
                     `https://browse.nypl.org/iii/encore/search/C__S${this.state.searchKeyword}__` +
                     'Orightresult__U?lang=eng&suite=def'

--- a/test/Application.test.js
+++ b/test/Application.test.js
@@ -10,6 +10,8 @@ describe('Application', () => {
 
   before(() => {
     component = shallow(<Application />);
+    // Set the state of searchKeyword to "duckie" right after it is shallow mounted
+    component.setState({ searchKeyword: 'duckie'});
   });
 
   it('is wrapped in a div.nyplGlobalSearchApp', () => {
@@ -20,5 +22,15 @@ describe('Application', () => {
     const title = component.find('h1');
     expect(title).to.have.length(1);
     expect(title.text()).to.equal('NYPL.org Search BETA');
+  });
+
+  it('should render a link to catalog search page with current search keywords.', () => {
+    const catalogSearchLink = component.find('.gs-search-catalog-link');
+
+    expect(component.find('.gs-search-catalog-link')).to.have.length(1);
+    expect(catalogSearchLink.text()).to.deep.equal('Find books, music, or movies instead >');
+    expect(catalogSearchLink.props().href).to.deep.equal(
+      'https://browse.nypl.org/iii/encore/search/C__Sduckie__Orightresult__U?lang=eng&suite=def'
+    );
   });
 });


### PR DESCRIPTION
This PR updates the texts for search catalog link, based on the latest request here
https://jira.nypl.org/browse/WWW-490

I also Added the related unit tests to it.

I didn't make the change to CHANGELOG because the documentation about adding the feature is already there. This PR does not include the update for the feature's functionality.

I also removed an empty component Tab.jsx