### PR TITLE
Fix selected tab and results in history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Adding commands for linting
 - Updating the syntax for better formatting codes in Results.jsx
 - Updating the texts for showing result information.
-- Updating the functions to render tabs on mobile view and deskttop view to fix the inconsistent selected tabs between viewports.
+- Updating the functions to render tabs on mobile view and desktop view to fix the inconsistent selected tabs between viewports.
 - Updating the function for getting URL paths so the results will be correct after hitting "Go back" button on browsers.
 #### Added
 - Adding the link to search the catalog with the same search keywords.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Adding commands for linting
 - Updating the syntax for better formatting codes in Results.jsx
 - Updating the texts for showing result information.
+- Updating the functions to render tabs on mobile view and deskttop view to fix the inconsistent selected tabs between viewports.
+- Updating the function for getting URL paths so the results will be correct after hitting "Go back" button on browsers.
 #### Added
 - Adding the link to search the catalog with the same search keywords.
 

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -26,11 +26,7 @@ history.listen(location => {
     action,
     pathname,
   } = location;
-
-  const keywordFromSearchBox = document.getElementById('gs-inputField').value;
-  const keywordFromPath = (pathname.split('/')[2]) ? pathname.split('/')[2] : '';
-  const searchKeyword = keywordFromSearchBox !== '' ? keywordFromSearchBox : keywordFromPath;
-
+  const searchKeyword = (pathname.split('/')[2]) ? pathname.split('/')[2] : '';
   const searchFacet = (pathname.split('/')[3]) ? pathname.split('/')[3] : '';
   const resultsStart = 0;
 

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -256,6 +256,7 @@ class Results extends React.Component {
     if (this.props.selectedFacet !== undefined && this.props.selectedFacet !== '') {
       const tabArray = this.props.tabs;
       let selectedTabName = '';
+
       tabArray.forEach((tab) => {
         if (tab.label === this.props.selectedFacet) {
           selectedTabName = tab.resultSummarydisplayName;

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -222,9 +222,7 @@ class TabItem extends React.Component {
 
     return (
       <div className="tabbed">
-        <div id='categoryTextDiv'>
-          <label htmlFor='category' id='categoryTextSpan'>Category</label>
-        </div>
+        <label id='categoryTextLabel'>Category</label>
         {this.renderMobileTabList(tabs, selectedFacet, tabNumber)}
         {this.renderDesktopTabList(tabs, selectedFacet, tabNumber)}
       </div>

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -104,22 +104,20 @@ class TabItem extends React.Component {
   render() {
     const {
       tabNumber,
-      selectedFacet,
       selectedFacetAnchor,
       selectValue
     } = this.state
 
     const {
-      tabs
+      tabs,
+      selectedFacet,
     } = this.props
 
     return (
       <div className="tabbed">
-
         <div id='categoryTextDiv'>
           <label htmlFor='category' id='categoryTextSpan'>Category</label>
         </div>
-
         <select className="form-control input-lg" value={selectValue} onChange={this.updateSelectedFacetMobile} aria-labelledby="categoryTextSpan category" id='category'>
           {selectedFacetAnchor}
           { tabs.map((tab, i) => {

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -4,29 +4,17 @@ import PropTypes from 'prop-types';
 class TabItem extends React.Component {
   constructor(props) {
     super(props);
-    this.clickHandler = this.clickHandler.bind(this);
+
     this.links = [];
     this.sections = [];
 
-    const {
-      tabs,
-      selectedFacet,
-    } = this.props;
-
     this.state = {
-      numberOfTabs: tabs.length,
-      selectedFacet: selectedFacet,
+      numberOfTabs: this.props.tabs.length,
     };
 
+    this.clickHandler = this.clickHandler.bind(this);
     this.keyDownHandler = this.keyDownHandler.bind(this);
     this.updateSelectedFacetMobile = this.updateSelectedFacetMobile.bind(this);
-  }
-
-  // componentDidMount will set the initial tab, either 1 or the number fetched from the
-  // url hash (to accommodate deep linking)
-  componentDidMount() {
-    let facetName = window.location.href.split("/").pop();
-    this.setState({selectedFacet: facetName,  tabNumber: "1"});
   }
 
   focusTab(newTabIndex) {
@@ -41,7 +29,7 @@ class TabItem extends React.Component {
       searchBySelectedFacetFunction
     } = this.props;
     saveSelectedTabValue(tabId);
-    this.setState({ tabNumber: newTabIndex.toString(), selectedFacet: tab });
+    this.setState({ tabNumber: newTabIndex.toString() });
     let newTab = this.links[newTabIndex];
     newTab.focus();
     searchBySelectedFacetFunction(tab);
@@ -100,6 +88,41 @@ class TabItem extends React.Component {
     searchBySelectedFacetFunction(e.target.value);
   }
 
+  // need to add documentations
+  renderMobileTabList(array, selectedFacet, tabNumber) {
+    const options= [];
+
+    array.forEach((tab, i) => {
+      const j = i + 1;
+      options.push(
+        <option
+          key={`${j}`}
+          value={tab.value}
+          className={(selectedFacet === tab.value ? 'activeTab' : null)}
+          href={`#tab${j}`}
+          id={`link${j}`}
+          tabIndex={!tabNumber ?  '0' : parseInt(tabNumber) === j ? null : -1}
+          aria-selected={tabNumber && j === parseInt(tabNumber) ? true: false}
+          data={`${j}`}
+        >
+          {tab.anchor}
+        </option>
+      );
+    });
+
+    return (
+      <select
+          className="form-control input-lg"
+          value={selectedFacet}
+          onChange={this.updateSelectedFacetMobile}
+          aria-labelledby="categoryTextSpan category"
+          id='category'
+        >
+        {options}
+      </select>
+    );
+  }
+
   render() {
     const {
       tabNumber,
@@ -115,33 +138,7 @@ class TabItem extends React.Component {
         <div id='categoryTextDiv'>
           <label htmlFor='category' id='categoryTextSpan'>Category</label>
         </div>
-        <select
-          className="form-control input-lg"
-          value={selectedFacet}
-          onChange={this.updateSelectedFacetMobile}
-          aria-labelledby="categoryTextSpan category"
-          id='category'
-        >
-          { tabs.map((tab, i) => {
-            let j = i + 1;
-            return (
-              <option
-                key={`${j}`}
-                value={tab.value}
-                className={(selectedFacet === tab.value ? 'activeTab' : null)}
-                href={`#tab${j}`}
-                id={`link${j}`}
-                tabIndex={!tabNumber ?  '0' : parseInt(tabNumber) === j ? null : -1}
-                aria-selected={tabNumber && j === parseInt(tabNumber) ? true: false}
-                data={`${j}`}
-              >
-                {tab.anchor}
-              </option>
-            )
-          })
-        }
-        </select>
-
+        {this.renderMobileTabList(tabs, selectedFacet, tabNumber)}
 
         <ul role='tablist'>
           { tabs.map((tab, i) => {

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -9,7 +9,8 @@ class TabItem extends React.Component {
     this.sections = [];
 
     this.state = {
-      numberOfTabs: this.props.tabs.length,
+      numberOfTabs: Array.isArray(this.props.tabs) && this.props.tabs.length ?
+        this.props.tabs.length : 0,
     };
 
     this.clickHandler = this.clickHandler.bind(this);
@@ -128,7 +129,7 @@ class TabItem extends React.Component {
   * @param {number} tabNumber - The number of each tab
   * @return {HTML Element} - The HTML element of the tab list on the mobile view
   */
-  renderMobileTabList(tabArray, selectedFacet, tabNumber) {
+  renderMobileTabList(tabArray = [], selectedFacet, tabNumber) {
     const tabOptions = [];
 
     tabArray.forEach((tab, i) => {
@@ -172,7 +173,7 @@ class TabItem extends React.Component {
   * @param {number} tabNumber - The number of each tab
   * @return {HTML Element} - The HTML element of the tab list on the desktop view
   */
-  renderDesktopTabList(tabArray, selectedFacet, tabNumber) {
+  renderDesktopTabList(tabArray = [], selectedFacet, tabNumber) {
     const tabItems = [];
 
     tabArray.forEach((tab, i) => {

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -22,7 +22,15 @@ class TabItem extends React.Component {
     newTab.focus();
   }
 
-  //switches tabs by updating state and href
+  /**
+   * switchTab(newTabIndex, tab, tabAnchor, tabId)
+   * Switches tabs by updating state and href.
+   *
+   * @param {int} newTabIndex - The tab number
+   * @param {string} tab - The value of the selected tab value
+   * @param {string} tabAnchor
+   * @param {string} tabId
+   */
   switchTab(newTabIndex, tab, tabAnchor, tabId) {
     const {
       saveSelectedTabValue,
@@ -35,6 +43,15 @@ class TabItem extends React.Component {
     searchBySelectedFacetFunction(tab);
   }
 
+  /**
+   * clickHandler(e, tabValue, tabAnchor, tabId)
+   * Calls the function switchTab after a key is pressed.
+   *
+   * @param {event} e - The input event
+   * @param {string} tabValue - The value of the selected tab value
+   * @param {string} tabAnchor
+   * @param {string} tabId
+   */
   clickHandler(e, tabValue, tabAnchor, tabId) {
     e.preventDefault();
     let clickedTab = e.currentTarget;
@@ -42,7 +59,15 @@ class TabItem extends React.Component {
     this.switchTab(index, tabValue, tabAnchor, tabId);
   }
 
-  //enables navigation with arrow keys
+  /**
+   * keyDownHandler(e, tabValue, tabAnchor, tabId)
+   * Enables navigation with arrow keys.
+   *
+   * @param {event} e - The events of key downs
+   * @param {string} tabValue
+   * @param {string} tabAnchor
+   * @param {string} tabId
+  */
   keyDownHandler(e, tabValue, tabAnchor, tabId) {
     const {
       numberOfTabs
@@ -81,6 +106,12 @@ class TabItem extends React.Component {
     }
   }
 
+  /**
+  * updateSelectedFacetMobile(e)
+  * Updates the facet on mobile view when a tab is selected.
+  *
+  * @param {event} e - The event when a tab is clicked
+  */
   updateSelectedFacetMobile(e){
     const {
       searchBySelectedFacetFunction
@@ -88,13 +119,22 @@ class TabItem extends React.Component {
     searchBySelectedFacetFunction(e.target.value);
   }
 
-  // need to add documentations
-  renderMobileTabList(array, selectedFacet, tabNumber) {
-    const options= [];
+  /**
+  * renderMobileTabList(tabArray, selectedFacet, tabNumber)
+  * Renders the tab list on the mobile view.
+  * 
+  * @param {array} tabArray - The array of the tabs
+  * @param {string} selectedFacet - The facet that is selected
+  * @param {number} tabNumber - The number of each tab
+  * @return {HTML Element} - The HTML element of the tab list on the mobile view
+  */
+  renderMobileTabList(tabArray, selectedFacet, tabNumber) {
+    const tabOptions = [];
 
-    array.forEach((tab, i) => {
+    tabArray.forEach((tab, i) => {
       const j = i + 1;
-      options.push(
+
+      tabOptions.push(
         <option
           key={`${j}`}
           value={tab.value}
@@ -112,14 +152,61 @@ class TabItem extends React.Component {
 
     return (
       <select
-          className="form-control input-lg"
-          value={selectedFacet}
-          onChange={this.updateSelectedFacetMobile}
-          aria-labelledby="categoryTextSpan category"
-          id='category'
-        >
-        {options}
+        className="form-control input-lg"
+        value={selectedFacet}
+        onChange={this.updateSelectedFacetMobile}
+        aria-labelledby="categoryTextSpan category"
+        id='category'
+      >
+        {tabOptions}
       </select>
+    );
+  }
+
+  /**
+  * renderDesktopTabList(tabArray, selectedFacet, tabNumber)
+  * Renders the tab list on the desktop view.
+  * 
+  * @param {array} tabArray - The array of the tabs
+  * @param {string} selectedFacet - The facet that is selected
+  * @param {number} tabNumber - The number of each tab
+  * @return {HTML Element} - The HTML element of the tab list on the desktop view
+  */
+  renderDesktopTabList(tabArray, selectedFacet, tabNumber) {
+    const tabItems = [];
+
+    tabArray.forEach((tab, i) => {
+      let j = i + 1;
+
+      tabItems.push(
+        <li
+          key={`${j}`}
+          value={tab.value}
+          id={`tab${j}`}
+          className={(selectedFacet === tab.value ? 'activeTab' : null)}
+          role='presentation'
+        >
+          <a
+            href={`#_tab${j}`}
+            id={`link${j}`}
+            tabIndex={selectedFacet === tab.value ? null : -1}
+            aria-selected={tabNumber && j === parseInt(tabNumber) ? true: false}
+            role='tab'
+            data={`${j}`}
+            onClick={e => this.clickHandler(e, tab.value, tab.anchor, j)}
+            onKeyDown={e => this.keyDownHandler(e, tab.value, tab.anchor, j)}
+            ref={(input) => {this.links[`${j}`] = input;}}
+          >
+            {tab.anchor}
+          </a>
+        </li>
+      );
+    });
+
+    return (
+      <ul role='tablist'>
+        {tabItems}
+      </ul>
     );
   }
 
@@ -139,30 +226,7 @@ class TabItem extends React.Component {
           <label htmlFor='category' id='categoryTextSpan'>Category</label>
         </div>
         {this.renderMobileTabList(tabs, selectedFacet, tabNumber)}
-
-        <ul role='tablist'>
-          { tabs.map((tab, i) => {
-            let j = i + 1;
-            return (
-              <li key={`${j}`} value={tab.value} id={`tab${j}`} className={(selectedFacet === tab.value ? 'activeTab' : null)} role='presentation'>
-                <a
-                  href={`#_tab${j}`}
-                  id={`link${j}`}
-                  tabIndex={selectedFacet === tab.value ? null : -1}
-                  aria-selected={tabNumber && j === parseInt(tabNumber) ? true: false}
-                  role='tab'
-                  data={`${j}`}
-                  onClick={e => this.clickHandler(e, tab.value, tab.anchor, j)}
-                  onKeyDown={e => this.keyDownHandler(e, tab.value, tab.anchor, j)}
-                  ref={(input) => {this.links[`${j}`] = input;}}
-                >
-                  {tab.anchor}
-                </a>
-              </li>
-        )
-    })
-  }
-        </ul>
+        {this.renderDesktopTabList(tabs, selectedFacet, tabNumber)}
       </div>
   );
   }

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -16,7 +16,6 @@ class TabItem extends React.Component {
     this.state = {
       numberOfTabs: tabs.length,
       selectedFacet: selectedFacet,
-      selectedFacetAnchor: 'All Results',
     };
 
     this.keyDownHandler = this.keyDownHandler.bind(this);
@@ -42,7 +41,7 @@ class TabItem extends React.Component {
       searchBySelectedFacetFunction
     } = this.props;
     saveSelectedTabValue(tabId);
-    this.setState({ tabNumber: newTabIndex.toString(), selectedFacet: tab, selectedFacetAnchor: tabAnchor});
+    this.setState({ tabNumber: newTabIndex.toString(), selectedFacet: tab });
     let newTab = this.links[newTabIndex];
     newTab.focus();
     searchBySelectedFacetFunction(tab);
@@ -104,8 +103,6 @@ class TabItem extends React.Component {
   render() {
     const {
       tabNumber,
-      selectedFacetAnchor,
-      selectValue
     } = this.state
 
     const {
@@ -118,8 +115,13 @@ class TabItem extends React.Component {
         <div id='categoryTextDiv'>
           <label htmlFor='category' id='categoryTextSpan'>Category</label>
         </div>
-        <select className="form-control input-lg" value={selectValue} onChange={this.updateSelectedFacetMobile} aria-labelledby="categoryTextSpan category" id='category'>
-          {selectedFacetAnchor}
+        <select
+          className="form-control input-lg"
+          value={selectedFacet}
+          onChange={this.updateSelectedFacetMobile}
+          aria-labelledby="categoryTextSpan category"
+          id='category'
+        >
           { tabs.map((tab, i) => {
             let j = i + 1;
             return (

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -29,7 +29,7 @@ class TabItem extends React.Component {
    *
    * @param {int} newTabIndex - The tab number
    * @param {string} tab - The value of the selected tab value
-   * @param {string} tabAnchor
+   * @param {string} tabAnchor - The value for a tab to be reand on the DOM
    * @param {string} tabId
    */
   switchTab(newTabIndex, tab, tabAnchor, tabId) {
@@ -50,7 +50,7 @@ class TabItem extends React.Component {
    *
    * @param {event} e - The input event
    * @param {string} tabValue - The value of the selected tab value
-   * @param {string} tabAnchor
+   * @param {string} tabAnchor - The value for a tab to be reand on the DOM
    * @param {string} tabId
    */
   clickHandler(e, tabValue, tabAnchor, tabId) {
@@ -66,7 +66,7 @@ class TabItem extends React.Component {
    *
    * @param {event} e - The events of key downs
    * @param {string} tabValue
-   * @param {string} tabAnchor
+   * @param {string} tabAnchor - The value for a tab to be reand on the DOM
    * @param {string} tabId
   */
   keyDownHandler(e, tabValue, tabAnchor, tabId) {

--- a/src/app/utils/MakeClientApiCall.js
+++ b/src/app/utils/MakeClientApiCall.js
@@ -22,7 +22,8 @@ const makeClientApiCall = (
   start = 0,
   callbackFunction = null,
   callbackFunctionNoKeyword = null,
-  callbackFunctionLoading = null) => {
+  callbackFunctionLoading = null
+) => {
   document.title = 'Search Results | NYPL.org';
   const searchFilter = (facet) ? ` more:${facet}` : '';
   const requestParameter = `${keyword}${searchFilter}`;

--- a/src/app/utils/MakeClientApiCall.js
+++ b/src/app/utils/MakeClientApiCall.js
@@ -24,7 +24,6 @@ const makeClientApiCall = (
   callbackFunctionNoKeyword = null,
   callbackFunctionLoading = null
 ) => {
-  document.title = 'Search Results | NYPL.org';
   const searchFilter = (facet) ? ` more:${facet}` : '';
   const requestParameter = `${keyword}${searchFilter}`;
 

--- a/src/app/utils/MakeClientApiCall.js
+++ b/src/app/utils/MakeClientApiCall.js
@@ -39,6 +39,7 @@ const makeClientApiCall = (
       })
       .catch(error => {
         console.log(`error calling API to search '${requestParameter}': ${error}`);
+
         if (callbackFunctionLoading) {
           callbackFunctionLoading(false);
         }

--- a/src/client/styles/components/_TabItem.scss
+++ b/src/client/styles/components/_TabItem.scss
@@ -3,7 +3,7 @@
   margin-top: 1.5rem;
 }
 
-#categoryTextDiv{
+#categoryTextLabel{
   display: none;
 }
 
@@ -12,21 +12,13 @@
 }
 
 @media (min-width:0px) and (max-width:1020px) {
-
-  .gs-results-divideLineIcon {
-    margin-top: 30px;
-  }
-
   div .tabbed ul[role="tablist"]{
     display: none;
   }
 
-  #categoryTextDiv{
-    display: inline;
-  }
-
   #category {
     display: inline;
+    margin-bottom: 24px;
     z-index: 1;
   }
 
@@ -58,7 +50,8 @@
 
   }
 
-  div .tabbed #categoryTextDiv{
+  div .tabbed #categoryTextLabel {
+    display: inline;
     float: left;
     font-size: 18px;
     font-family: Kievit-Book;

--- a/test/Application.test.js
+++ b/test/Application.test.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import Application from './../src/app/components/Application/Application.jsx';
 
-
 describe('Application', () => {
   let component;
 

--- a/test/TabItem.test.js
+++ b/test/TabItem.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import TabItem from './../src/app/components/TabItem/TabItem.jsx';
+
+describe('TabItem', () => {
+  let component;
+
+  describe('if there is no tab array', () => {
+    let component;
+
+    before(() => {
+      component = shallow(<TabItem />);
+    });
+
+    it('should render no options of the tab list on mobile view.', () => {
+      expect(component.find('select')).to.have.length(1);
+      expect(component.find('select').find('option')).to.have.length(0);
+    });
+
+    it('should render no list items of the tab list on desktop view.', () => {
+      expect(component.find('ul')).to.have.length(1);
+      expect(component.find('ul').find('li')).to.have.length(0);
+    });
+  });
+
+  describe('if there are three tabs passed down to the component', () => {
+    let component;
+    const tabs = [{ anchor: 'All' }, { anchor: 'Database' }, { anchor: 'Blogs' }];
+
+    before(() => {
+      component = shallow(<TabItem tabs={tabs} />);
+    });
+
+    it('should render 3 options of the tab list on mobile view.', () => {
+      expect(component.find('select')).to.have.length(1);
+      expect(component.find('select').find('option')).to.have.length(3);
+    });
+
+    it('should render the option values with correct anchors.', () => {
+      expect(component.find('select').find('option').at(0).text()).to.deep.equal('All');
+      expect(component.find('select').find('option').at(1).text()).to.deep.equal('Database');
+      expect(component.find('select').find('option').at(2).text()).to.deep.equal('Blogs');
+    });
+
+    it('should render 3 list items of the tab list on desktop view.', () => {
+      expect(component.find('ul')).to.have.length(1);
+      expect(component.find('ul').find('li')).to.have.length(3)
+    });
+
+    it('should render the list item values with correct anchors.', () => {
+      expect(component.find('ul').find('li').at(0).text()).to.deep.equal('All');
+      expect(component.find('ul').find('li').at(1).text()).to.deep.equal('Database');
+      expect(component.find('ul').find('li').at(2).text()).to.deep.equal('Blogs');
+    });
+  });
+});


### PR DESCRIPTION
Finally made the PR!!! This PR focuses on fix the issues from tickets
https://jira.nypl.org/browse/WWW-546
And part of the ticket https://jira.nypl.org/browse/WWW-518

The PR fixes the issue for browsing back and forth using Go back and Forward buttons on the browsers. It also fixes the issue the selected tab are different between mobile and desktop view. It also adds related styles updates. And finally, the tests.

The main work is done in TabItem.jsx. There is also some code cleaning aside the function updates.

The PR does not fix the issue of the second search for the same keywords and facet. It will be another PR.

Thanks for @nnat425 's contribution for TabItem.jsx updates and the scss adjustments!