### PR TITLE
Faster focus on next page of search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 ### v0.3.12
 #### Updated
-- Note: we'll add all changes here until the deployment around December 11th
+- Note: we'll add all changes here until the deployment around December 18th
 - Removing role and aria-atomic from area that announces the search results
 - Changing the label for the search field
 - Removing loading screen
@@ -14,6 +14,7 @@
 - Updating the syntax for better formatting codes in Results.jsx
 - Updating the texts for showing result information.
 - Changing the "Load More" button to "View More" and removing the loading dots
+- Speeding up the change in focus after clicking "View More"
 #### Added
 - Adding the link to search the catalog with the same search keywords.
 - Add chevron to mobile dropdown

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -127,6 +127,7 @@ class Results extends React.Component {
    */
   addMoreResults() {
     const nextResultCount = this.state.resultsStart + this.state.incrementResults;
+    let originalResultsStart = this.state.resultsStart;
 
     makeClientApiCall(this.props.searchKeyword, this.props.selectedFacet, nextResultCount,
       (searchResultsItems) => {
@@ -153,11 +154,20 @@ class Results extends React.Component {
     );
 
     // Automatically focus on the first item of the newly reloaded results
-    setTimeout(() => {
-      const refResultIndex = `result-${this.state.resultsStart}`;
+    let counter = 1;
+    var moveFocusToNextPage = () => {
+      setTimeout(() => {
+        counter += 1;
+        if (originalResultsStart != this.state.resultsStart){
+          const refResultIndex = `result-${this.state.resultsStart}`;
+          ReactDOM.findDOMNode(this.refs[refResultIndex].refs[`${refResultIndex}-item`]).focus();
+        } else if (counter < 20) {
+          moveFocusToNextPage();
+        }
+      }, 500);
+    }
 
-      ReactDOM.findDOMNode(this.refs[refResultIndex].refs[`${refResultIndex}-item`]).focus();
-    }, 2000);
+    moveFocusToNextPage();
   }
 
   /**

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -37,6 +37,7 @@ class Results extends React.Component {
     this.addMoreResults = this.addMoreResults.bind(this);
     this.onChange = this.onChange.bind(this);
     this.saveSelectedTabValue = this.saveSelectedTabValue.bind(this);
+    this.moveFocusToNextPage = this.moveFocusToNextPage.bind(this);
   }
 
   componentDidMount() {
@@ -153,21 +154,23 @@ class Results extends React.Component {
       }
     );
 
-    // Automatically focus on the first item of the newly reloaded results
-    let counter = 1;
-    var moveFocusToNextPage = () => {
-      setTimeout(() => {
-        counter += 1;
-        if (originalResultsStart != this.state.resultsStart){
-          const refResultIndex = `result-${this.state.resultsStart}`;
-          ReactDOM.findDOMNode(this.refs[refResultIndex].refs[`${refResultIndex}-item`]).focus();
-        } else if (counter < 20) {
-          moveFocusToNextPage();
-        }
-      }, 500);
-    }
+    this.moveFocusToNextPage(originalResultsStart, 0);
+  }
 
-    moveFocusToNextPage();
+  /**
+   * moveFocusToNextPage(snippetText)
+   * Move the page focus to the first item in the next page of search results.
+   */
+  moveFocusToNextPage(originalResultsStart, counter) {
+    setTimeout(() => {
+      counter += 1;
+      if (originalResultsStart != this.state.resultsStart){
+        const refResultIndex = `result-${this.state.resultsStart}`;
+        ReactDOM.findDOMNode(this.refs[refResultIndex].refs[`${refResultIndex}-item`]).focus();
+      } else if (counter < 20) {
+        moveFocusToNextPage(originalResultsStart, counter);
+      }
+    }, 500);
   }
 
   /**
@@ -291,7 +294,6 @@ class Results extends React.Component {
           selectedFacet={this.props.selectedFacet}
           searchBySelectedFacetFunction={this.props.searchBySelectedFacetFunction}
           saveSelectedTabValue={this.saveSelectedTabValue}
-          resultsOlElement={() => this.refs['resultsOlElement']}
         />
         {(typeof results.length !== 'undefined') && results.length !== 0 &&
           <div>
@@ -307,7 +309,7 @@ class Results extends React.Component {
               viewBox="0 0 84 4"
               width="84"
             />
-            <ol id={this.props.id} className={this.props.className} ref="resultsOlElement" tabIndex='0' aria-labelledby={`link${this.state.tabIdValue}`}>
+            <ol id={this.props.id} className={this.props.className} ref="results">
               {results}
             </ol>
             {


### PR DESCRIPTION
There used to be a 2-second delay between clicking the "View More" button and the focus getting set to the first search result that gets returned after that button click.

If a user has a slow connection that doesn't return the results for more than 2 seconds than the focus would not change.

For users with fast connections, the 2-second delay seemed slow.

In this PR, we fix the problem, by checking to see if the state of the app is updated with the new search results every 1/2 second, and then we move the focus once the state has been updated.