### PR TITLE
align layout to lion and clean up style

### DIFF
--- a/src/client/styles/components/_InputField.scss
+++ b/src/client/styles/components/_InputField.scss
@@ -1,17 +1,16 @@
 .gs-inputField {
+  @include Kievit-Book-Italic;
+
   border: 2px solid $BLACK_COLOR;
   border-radius: 3px;
   box-sizing: border-box;
   color: $INPUT_FIELD_GREY;
-  font-size: 16px;
-  font-style: italic;
-  line-height: 21px;
+  font-size: 18px;
   padding: 13px 12px;
   width: 100%;
 
   &-wrapper {
     padding: 0 14px;
-    margin: 0 0 22px 0;
 
     @include layout-at(7, $tablet-portrait) {
       @include grid-span(3, 1);

--- a/src/client/styles/components/_Results.scss
+++ b/src/client/styles/components/_Results.scss
@@ -3,9 +3,7 @@
   padding: 0;
 
   @include layout-at(8, $tablet-landscape) {
-    @include grid-span(6, 1);
-
-    margin: 20px 0 0 0;
+    @include grid-span(7, 1);
   }
 
   &-wrapper {
@@ -14,21 +12,24 @@
     padding: 30px 14px 0 14px;
 
     @include layout-at(7, $tablet-portrait) {
-      padding: 0 36px;
+      padding: 0 20px;
     }
 
-    @include layout-at(9, $tablet-landscape) {
-      @include grid-span(8, 2);
-
-      padding: 0;
+    @include layout-at(8, $tablet-landscape) {
+      padding: 0 0 0 2rem;
     }
   }
 
   &-length {
+    @include layout-at(8, $tablet-landscape) {
+      @include grid-span(8, 1);
+    }
+
     color: $BLACK_COLOR;
     font-size: 16px;
     line-height: 20px;
     margin: 0 0 16px 0;
+    width: 100%;
 
     @include min-screen($tablet-landscape){
       margin: 0 0 16px 0;
@@ -40,7 +41,7 @@
   }
 
   &Item {
-    border-bottom: 2px solid $LIGHTGRAY_COLOR;
+    border-bottom: 1px solid $LIGHTGRAY_COLOR;
     list-style-type: none;
     margin: 0 0 16px 0;
 
@@ -67,11 +68,12 @@
       line-height: 1.5;
       font-weight: normal;
       text-decoration: underline;
+      margin: 0 0 8px 0;
 
       @include layout-at(7, $tablet-portrait) {
         @include grid-span(6, 1);
 
-        margin: 0 0 12px 0;
+        margin: 0 0 8px 0;
         margin-right: 0 !important;
       }
 
@@ -99,6 +101,7 @@
         @include layout-at(7, $tablet-portrait) {
           @include grid-span(1, 7);
           display: block;
+          margin-bottom: 24px;
         }
 
         @include layout-at(6, $tablet-landscape) {
@@ -122,7 +125,7 @@
       }
 
       @include layout-at(6, $tablet-landscape) {
-        @include grid-span(4, 1);
+        @include grid-span(5, 1);
 
         margin: 0;
       }
@@ -130,6 +133,7 @@
 
     &-label {
       @include Kievit-Bold;
+
       color: $SEARCH_BLUE;
       font-size: 13px;
       letter-spacing: .04em;
@@ -151,21 +155,24 @@
     }
 
     &-linkText {
+      @include Kievit-Book-Italic;
+
       color: $DARKGRAY_COLOR;
       font-size: 14px;
-      line-height: 16px;
+      line-height: 1.25;
+      margin: 0 0 8px 0;
       word-break: break-all;
 
       @include layout-at(7, $tablet-portrait) {
         @include grid-span(5, 1);
 
-        margin: 0 0 12px 0;
+        margin: 0 0 8px 0;
       }
 
       @include layout-at(6, $tablet-landscape) {
         @include grid-span(4, 1);
 
-        margin: 0 0 12px 0;
+        margin: 0 0 8px 0;
       }
     }
   }
@@ -196,25 +203,15 @@ p#search-results-summary {
 }
 
 a:focus {
-  box-shadow: none; 
-  -webkit-outline-color: #135772; 
-  -moz-outline-color: #135772; 
-  -ms-outline-color: #135772; 
-  -o-outline-color: #135772; 
-  outline-color: #135772; 
-  outline-style: none; 
-  outline-width: .1875em;
-
+  @include a11y-focus($SEARCH_BLUE_DARK, 4px);
 }
 
 a:focus .gs-resultsItem-title, a:focus .gs-resultsItem-imageWrapper, .gs-results-paginationButton:focus, .gs-inputField:focus, .gs-search-catalog-link-wrapper a:focus, .returnLink a:focus {
-  box-shadow: 1px 1px 1px 1px #135772; 
-  -webkit-outline-color: #135772; 
-  -moz-outline-color: #135772; 
-  -ms-outline-color: #135772; 
-  -o-outline-color: #135772; 
-  outline-color: #135772; 
-  outline-style: solid; 
-  outline-width: .1875em;
+  @include a11y-focus($SEARCH_BLUE_DARK, 4px);
 }
 
+h2.gs-resultsItem-title.whole-row {
+  @include min-screen($tablet-portrait) {
+    @include a11y-focus(transparent, 0);
+  }
+}

--- a/src/client/styles/components/_SearchButton.scss
+++ b/src/client/styles/components/_SearchButton.scss
@@ -9,12 +9,12 @@
   font-size: 16px;
   letter-spacing: .04em;
   line-height: 14px;
-  padding: 10px 20px;
+  padding: 6.5px 20px;
   text-align: center;
   width: 100%;
 
   @include layout-at(7, $tablet-portrait) {
-    padding: 8px 35px;
+    padding: 6.5px 35px;
   }
 
   span {
@@ -22,7 +22,7 @@
   }
 
   &-wrapper {
-    margin: 0 0 15px 0;
+    margin: 8px 0 15px 0;
     padding: 0 14px;
 
     @include layout-at(7, $tablet-portrait) {

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -54,7 +54,6 @@ header {
   @include layout-at(9, $tablet-landscape) {
     box-sizing: border-box;
     min-height: 860px;
-    padding: 0 20px;
   }
 
   @include min-screen($desktop) {
@@ -76,21 +75,14 @@ header {
     padding: 0 14px;
 
     @include min-screen($tablet-portrait) {
-      padding: 0 36px;
+      padding: 24px 0 0 20px;
     }
 
     @include layout-at(9, $tablet-landscape) {
-      @include grid-span(8, 2);
+      @include grid-span(9, 2);
 
       margin: 32px 0 0 0;
-      padding: 0;
-    }
-
-    span {
-      &:last-child {
-        font-size: 12px;
-        vertical-align: 12px;
-      }
+      padding: 0 0 0 2rem;
     }
   }
 
@@ -103,14 +95,14 @@ header {
       box-sizing: border-box;
       display: inline-block;
       margin: 0 0 27px 0;
-      padding: 0 36px;
+      padding: 0 20px;
     }
 
     @include layout-at(9, $tablet-landscape) {
-      @include grid-span(8, 2);
+      @include grid-span(9, 2);
 
       margin: 30px 0 27px 0;
-      padding: 0 20px 0 0;
+      padding: 0 20px 0 2rem;
     }
   }
 
@@ -145,12 +137,17 @@ header {
     }
 
     a {
-      position: relative;
-      top: 16px;
+      @include Kievit-Book-Italic;
+
       color: $SEARCH_BLUE;
+      position: relative;
+      text-decoration: none;
+      top: 16px;
+
 
       &:hover {
         color: $SEARCH_BLUE_DARK;
+        text-decoration: underline;
         transition: color $DURATION_LONG ease;
       }
     }

--- a/src/client/styles/utils/_mixins.scss
+++ b/src/client/styles/utils/_mixins.scss
@@ -238,3 +238,15 @@
 $DURATION_SHORT: .1s;
 $DURATION_MEDIUM: .3s;
 $DURATION_LONG: .6s;
+
+/* focus color */
+@mixin a11y-focus($a11y-color, $a11y-border-width){
+  box-shadow: 1px 1px 1px 1px $a11y-color; 
+  -webkit-outline-color: $a11y-color; 
+  -moz-outline-color: $a11y-color; 
+  -ms-outline-color: $a11y-color; 
+  -o-outline-color: $a11y-color; 
+  outline-color: $a11y-color; 
+  outline-style: solid; 
+  outline-width: $a11y-border-width;
+}


### PR DESCRIPTION
Ran into some rebase issue in this PR(https://github.com/NYPL/dgx-global-search/pull/96) as I originally created the **clean-up** branch off of **development**.

- Addresses **WWW-558** Align page elements with lion (not logotype)
- Addresses parts of **WWW-547** Search Style Clean up - Phase 1
- Removes styling for "BETA" in prep for it's removal
- Creates a mixin for accessibility focus border

@ktp242 addressed your latest comment in https://github.com/NYPL/dgx-global-search/pull/96 : https://github.com/NYPL/dgx-global-search/pull/96#issuecomment-446730558