### PR TITLE
Da/back bug

### DIFF
--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -21,6 +21,7 @@ import ReturnLink from '../ReturnLink/ReturnLink.jsx';
 // Import utilities
 import { makeClientApiCall } from '../../utils/MakeClientApiCall.js';
 import { generateSearchedFrom, nativeGA } from '../../utils/GAUtils.js';
+import getNumberForFacet from '../../utils/TabIndex.js'
 
 class Results extends React.Component {
   constructor(props) {
@@ -342,7 +343,7 @@ class Results extends React.Component {
               viewBox="0 0 84 4"
               width="84"
             />
-            <ol id={this.props.id} className={this.props.className} ref="resultsOlElement" tabIndex="0" aria-labelledby={`link${this.state.tabIdValue}`}>
+          <ol id={this.props.id} className={this.props.className} ref="resultsOlElement" tabIndex="0" aria-labelledby={`link${getNumberForFacet(this.props.selectedFacet)}`}>
               {results}
             </ol>
             {

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -295,7 +295,7 @@ class Results extends React.Component {
         }
       });
 
-      resultsNumberSuggestion += ` in ${selectedTabName}`;
+      resultsNumberSuggestion ? resultsNumberSuggestion += ` in ${selectedTabName}` : null;
     }
 
     return (

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -295,7 +295,7 @@ class Results extends React.Component {
         }
       });
 
-      resultsNumberSuggestion ? resultsNumberSuggestion += ` in ${selectedTabName}` : null;
+      resultsNumberSuggestion += (resultsNumberSuggestion ? ` in ${selectedTabName}` : '');
     }
 
     return (

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Actions from '../../actions/Actions.js';
 import Store from '../../stores/Store.js';
+import getNumberForFacet from '../../utils/TabIndex.js'
 
 class TabItem extends React.Component {
   constructor(props) {
@@ -20,7 +21,7 @@ class TabItem extends React.Component {
         tabs.length : 0,
       tabs: tabs,
       selectedFacet: selectedFacet,
-      tabNumber: this.getNumberForFacet(selectedFacet)
+      tabNumber: getNumberForFacet(selectedFacet)
     };
 
     this.clickHandler = this.clickHandler.bind(this);
@@ -42,23 +43,8 @@ class TabItem extends React.Component {
     console.log('facet: ', facet)
     this.setState({
       selectedFacet: facet,
-      tabNumber: this.getNumberForFacet(facet)
+      tabNumber: getNumberForFacet(facet)
     })
-  }
-
-
-  getNumberForFacet(facet) {
-    const facets = [
-      '',
-      'articles_databases',
-      'research_guides',
-      'events_classes',
-      'exhibitions',
-      'blog_posts',
-      'audio_video',
-      'help_articles',
-      'locations']
-    return facets.indexOf(facet) + 1;
   }
 
   focusTab(newTabIndex) {

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -40,7 +40,6 @@ class TabItem extends React.Component {
 
   onChange() {
     let facet = Store.getState().selectedFacet;
-    console.log('facet: ', facet)
     this.setState({
       selectedFacet: facet,
       tabNumber: getNumberForFacet(facet)
@@ -67,7 +66,6 @@ class TabItem extends React.Component {
     } = this.props;
     // saveSelectedTabValue(tabId);
     Actions.updateSelectedFacet(tab)
-    // this.setState({ tabNumber: newTabIndex.toString(), selectedFacet: tab });
     let newTab = this.links[newTabIndex];
     newTab.focus();
     searchBySelectedFacetFunction(tab);
@@ -145,9 +143,7 @@ class TabItem extends React.Component {
       searchBySelectedFacetFunction
     } = this.props;
     Actions.updateSelectedFacet(e.target.value);
-    // this.setState({selectedFacet: e.target.value})
     searchBySelectedFacetFunction(e.target.value);
-
   }
 
   /**
@@ -211,7 +207,6 @@ class TabItem extends React.Component {
   *
   * @param {array} tabArray - The array of the tabs
   * @param {string} selectedFacet - The facet that is selected
-  * @param {number} tabNumber - The number of each tab
   * @return {HTML Element} - The HTML element of the tab list on the desktop view
   */
   renderDesktopTabList(tabArray = [], selectedFacet) {
@@ -219,7 +214,6 @@ class TabItem extends React.Component {
     const {
       tabNumber
     } = this.state;
-    console.log('tabNumber: ', tabNumber)
     tabArray.forEach((tab, i) => {
       let j = i + 1;
       tabItems.push(
@@ -260,7 +254,6 @@ class TabItem extends React.Component {
   *
   * @param {array} tabArray - The array of the tabs
   * @param {string} selectedFacet - The facet that is selected
-  * @param {number} tabNumber - The number of each tab
   * @return {HTML Element} - The HTML element that contains both of the tab lists
   */
   renderContentOfTabLists(tabArray = [], selectedFacet) {
@@ -280,14 +273,13 @@ class TabItem extends React.Component {
   render() {
 
     const {
-      tabNumber,
       tabs,
       selectedFacet,
     } = this.state
 
     return (
       <div className="tabsContainer">
-        {this.renderContentOfTabLists(tabs, selectedFacet, tabNumber)}
+        {this.renderContentOfTabLists(tabs, selectedFacet)}
       </div>
     );
   }

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Actions from '../../actions/Actions.js';
+import Store from '../../stores/Store.js';
 
 class TabItem extends React.Component {
   constructor(props) {
@@ -26,9 +27,38 @@ class TabItem extends React.Component {
     this.updateSelectedFacetMobile = this.updateSelectedFacetMobile.bind(this);
   }
 
+  componentDidMount() {
+    Store.listen(this.onChange);
+  }
+
+  componentWillUnmount() {
+    Store.unlisten(this.onChange);
+  }
+
+  onChange() {
+    let facet = Store.getState().selectedFacet;
+    this.setState({
+      selectedFacet: facet,
+      tabNumber: this.getNumberForFacet(facet)
+    })
+  }
+
+
+  getNumberForFacet(facet) {
+    const facets = [
+      'articles_databases',
+      'research_guides',
+      'events_classes',
+      'exhibitions',
+      'blog_posts',
+      'audio_video',
+      'help_articles',
+      'locations']
+    return facets.indexOf(facet) + 1;
+  }
+
   focusTab(newTabIndex) {
     let newTab = this.links[newTabIndex];
-
     newTab.focus();
   }
 
@@ -45,9 +75,9 @@ class TabItem extends React.Component {
       saveSelectedTabValue,
       searchBySelectedFacetFunction
     } = this.props;
-    saveSelectedTabValue(tabId);
+    // saveSelectedTabValue(tabId);
     Actions.updateSelectedFacet(tab)
-    this.setState({ tabNumber: newTabIndex.toString(), selectedFacet: tab });
+    // this.setState({ tabNumber: newTabIndex.toString(), selectedFacet: tab });
     let newTab = this.links[newTabIndex];
     newTab.focus();
     searchBySelectedFacetFunction(tab);
@@ -125,7 +155,7 @@ class TabItem extends React.Component {
       searchBySelectedFacetFunction
     } = this.props;
     Actions.updateSelectedFacet(e.target.value);
-    this.setState({selectedFacet: e.target.value})
+    // this.setState({selectedFacet: e.target.value})
     searchBySelectedFacetFunction(e.target.value);
 
   }

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -19,7 +19,8 @@ class TabItem extends React.Component {
       numberOfTabs: Array.isArray(tabs) && tabs.length ?
         tabs.length : 0,
       tabs: tabs,
-      selectedFacet: selectedFacet
+      selectedFacet: selectedFacet,
+      tabNumber: this.getNumberForFacet(selectedFacet)
     };
 
     this.clickHandler = this.clickHandler.bind(this);
@@ -48,6 +49,7 @@ class TabItem extends React.Component {
 
   getNumberForFacet(facet) {
     const facets = [
+      '',
       'articles_databases',
       'research_guides',
       'events_classes',
@@ -171,9 +173,11 @@ class TabItem extends React.Component {
   * @param {number} tabNumber - The number of each tab
   * @return {HTML Element} - The HTML element of the tab list on the mobile view
   */
-  renderMobileTabList(tabArray = [], selectedFacet, tabNumber) {
+  renderMobileTabList(tabArray = [], selectedFacet) {
     const tabOptions = [];
-
+    const {
+      tabNumber
+    } = this.state;
     tabArray.forEach((tab, i) => {
       const j = i + 1;
       let tabIndexAttribute;
@@ -224,8 +228,12 @@ class TabItem extends React.Component {
   * @param {number} tabNumber - The number of each tab
   * @return {HTML Element} - The HTML element of the tab list on the desktop view
   */
-  renderDesktopTabList(tabArray = [], selectedFacet, tabNumber) {
+  renderDesktopTabList(tabArray = [], selectedFacet) {
     const tabItems = [];
+    const {
+      tabNumber
+    } = this.state;
+    console.log('tabNumber: ', tabNumber)
     tabArray.forEach((tab, i) => {
       let j = i + 1;
       tabItems.push(
@@ -269,7 +277,7 @@ class TabItem extends React.Component {
   * @param {number} tabNumber - The number of each tab
   * @return {HTML Element} - The HTML element that contains both of the tab lists
   */
-  renderContentOfTabLists(tabArray = [], selectedFacet, tabNumber) {
+  renderContentOfTabLists(tabArray = [], selectedFacet) {
     if (!tabArray.length) {
       return null;
     }
@@ -277,8 +285,8 @@ class TabItem extends React.Component {
     return (
       <div>
         <label id='categoryTextLabel'>Category</label>
-        {this.renderMobileTabList(tabArray, selectedFacet, tabNumber)}
-        {this.renderDesktopTabList(tabArray, selectedFacet, tabNumber)}
+        {this.renderMobileTabList(tabArray, selectedFacet)}
+        {this.renderDesktopTabList(tabArray, selectedFacet)}
       </div>
     );
   }

--- a/src/app/components/TabItem/TabItem.jsx
+++ b/src/app/components/TabItem/TabItem.jsx
@@ -25,6 +25,7 @@ class TabItem extends React.Component {
     this.clickHandler = this.clickHandler.bind(this);
     this.keyDownHandler = this.keyDownHandler.bind(this);
     this.updateSelectedFacetMobile = this.updateSelectedFacetMobile.bind(this);
+    this.onChange = this.onChange.bind(this);
   }
 
   componentDidMount() {
@@ -37,6 +38,7 @@ class TabItem extends React.Component {
 
   onChange() {
     let facet = Store.getState().selectedFacet;
+    console.log('facet: ', facet)
     this.setState({
       selectedFacet: facet,
       tabNumber: this.getNumberForFacet(facet)

--- a/src/app/utils/TabIndex.js
+++ b/src/app/utils/TabIndex.js
@@ -1,0 +1,15 @@
+const getNumberForFacet = (facet) => {
+  const facets = [
+    '',
+    'articles_databases',
+    'research_guides',
+    'events_classes',
+    'exhibitions',
+    'blog_posts',
+    'audio_video',
+    'help_articles',
+    'locations']
+  return facets.indexOf(facet) + 1;
+}
+
+export default getNumberForFacet;


### PR DESCRIPTION
A previous commit broke the back button in such a way that the selected tab did not change when pressing back. This fixes that bug. In addition, this commit 1) removes all state setting from the tabItem component, reducing responsibility for setting the current tab to the Store and 2) calculates the index of the current tab from its value, removing the possibility of conflict between these two indicators of the current tab