### PR TITLE
Revert 100% width for divider icon

### DIFF
--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -340,12 +340,12 @@ class Results extends React.Component {
               ariaHidden
               className={`${this.props.className}-divideLineIcon`}
               height="4"
-              length="100%"
+              length="84"
               stroke="transparent"
               strokeWidth="4"
               title="divide.line.icon.svg"
-              viewBox="0 0 100% 4"
-              width="100%"
+              viewBox="0 0 84 4"
+              width="84"
             />
             <ol id={this.props.id} className={this.props.className}  >
               {results}


### PR DESCRIPTION
@jackkim9 here's the before & after screenshots to show that there are fewer errors in the console after the CSS fix you suggested.

The other console errors are getting fixed by others on the team.

## BEFORE
![screen shot 2018-12-17 at 5 23 55 pm](https://user-images.githubusercontent.com/1825103/50119406-b3c8c880-0220-11e9-84bf-be0789aba520.png)

## AFTER
![screen shot 2018-12-17 at 5 24 17 pm](https://user-images.githubusercontent.com/1825103/50119428-c216e480-0220-11e9-83f8-824e2ae26b26.png)
