### PR TITLE
Update no keyword input notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.0.2
+#### Added
+- Adding the instruction message to ask the user to enter a search keyword.
+
 ### v1.0.1
 #### Updated
 - Updating @nypl/dgx-header-component to 2.4.19

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -150,6 +150,7 @@ class App extends React.Component {
     if (!this.state.searchKeyword) {
       Actions.updateSelectedFacet(selectedFacet);
       Actions.updateIsKeywordValid(false);
+      Actions.updateSearchKeyword('');
     } else {
       makeClientApiCall(this.state.searchKeyword, selectedFacet, 0,
         (searchResultsItems, resultLength) => {

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -149,17 +149,21 @@ class App extends React.Component {
    * @param {string} selectedFacet
    */
   submitSearchRequest(selectedFacet = '') {
-    if (!this.state.searchKeyword) {
+    const {
+      searchKeyword,
+    } = this.state;
+
+    if (!searchKeyword) {
       Actions.updateSelectedFacet(selectedFacet);
       Actions.updateIsKeywordValid(false);
       Actions.updateSearchKeyword('');
     } else {
       makeClientApiCall(
-        this.state.searchKeyword,
+        searchKeyword,
         selectedFacet,
         0,
         (searchResultsItems, resultLength) => {
-          const currentSearchKeyword = this.state.searchKeyword.trim() || '';
+          const currentSearchKeyword = searchKeyword.trim() || '';
           const facet = selectedFacet;
 
           // Update and transit to the match URL
@@ -198,9 +202,13 @@ class App extends React.Component {
    * @param {object} event
    */
   triggerSubmit(event) {
+    const {
+      selectedFacet,
+    } = this.state;
+
     if (event) {
       if (event.keyCode === 13 || event.key === 'Enter') {
-        this.triggerGAThenSubmit(this.state.selectedFacet);
+        this.triggerGAThenSubmit(selectedFacet);
       }
     }
   }
@@ -214,13 +222,18 @@ class App extends React.Component {
    * @param {string} selectedFacet
    */
   triggerGAThenSubmit(selectedFacet = '') {
+    const {
+      searchKeyword,
+      isGAQuerySent,
+    } = this.state;
+
     // Only trigger search and GA QuerySent event one time if double or tripple clicks happen
-    if (!this.state.isGAQuerySent) {
+    if (!isGAQuerySent) {
       // Set isGAQuerySent to be true to avoid another event being sent in a short period of time
       this.setState({ isGAQuerySent: true });
       nativeGA(
         'QuerySent',
-        this.state.searchKeyword,
+        searchKeyword,
         0,
         'BetaSearchForm',
         null,
@@ -247,18 +260,26 @@ class App extends React.Component {
    * @return {object} object
    */
   renderResults(searchKeyword, searchResultsArray, searchResultsLength, isKeywordValid) {
+    const {
+      tabIdValue,
+      searchFacets,
+      selectedFacet,
+      resultsStart,
+      queriesForGA,
+    } = this.state;
+
     return (
       <Results
-        selectedTab={this.state.tabIdValue}
+        selectedTab={tabIdValue}
         amount={searchResultsLength}
         results={searchResultsArray}
         id="gs-results"
         className="gs-results"
         searchKeyword={searchKeyword}
-        tabs={this.state.searchFacets}
-        selectedFacet={this.state.selectedFacet}
-        resultsStart={this.state.resultsStart}
-        queriesForGA={this.state.queriesForGA}
+        tabs={searchFacets}
+        selectedFacet={selectedFacet}
+        resultsStart={resultsStart}
+        queriesForGA={queriesForGA}
         searchBySelectedFacetFunction={this.searchBySelectedFacet}
         isKeywordValid={isKeywordValid}
       />
@@ -266,7 +287,12 @@ class App extends React.Component {
   }
 
   render() {
-    const inputValue = this.state.searchKeyword || '';
+    const {
+      resultsComponentData,
+      searchKeyword,
+      selectedFacet,
+    } = this.state;
+    const inputValue = searchKeyword || '';
     const inputPlaceholder = 'What would you like to find?';
 
     return (
@@ -295,14 +321,14 @@ class App extends React.Component {
                     id="gs-searchButton"
                     className="gs-searchButton"
                     label="SEARCH"
-                    onClick={() => this.triggerGAThenSubmit(this.state.selectedFacet)}
+                    onClick={() => this.triggerGAThenSubmit(selectedFacet)}
                   />
                 </div>
                 <div className="gs-search-catalog-link-wrapper">
                   <a
                     className="gs-search-catalog-link"
                     href={
-                      `https://browse.nypl.org/iii/encore/search/C__S${this.state.searchKeyword}__`
+                      `https://browse.nypl.org/iii/encore/search/C__S${searchKeyword}__`
                       + 'Orightresult__U?lang=eng&suite=def'
                     }
                   >
@@ -311,7 +337,7 @@ class App extends React.Component {
                 </div>
 
               </div>
-              {this.state.resultsComponentData}
+              {resultsComponentData}
             </div>
           </div>
         </main>

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -84,7 +84,8 @@ class App extends React.Component {
       resultsComponentData: this.renderResults(
         Store.getState().searchKeyword,
         Store.getState().searchData,
-        Store.getState().searchDataLength
+        Store.getState().searchDataLength,
+        Store.getState().isKeywordValid
       ),
     });
   }
@@ -102,14 +103,14 @@ class App extends React.Component {
   onChange() {
     // Updates the state with the new search data
     this.setState({
-      isKeywordValid: true,
       isLoading: false,
       searchKeyword: Store.getState().searchKeyword,
       selectedFacet: Store.getState().selectedFacet,
       resultsComponentData: this.renderResults(
         Store.getState().searchKeyword,
         Store.getState().searchData,
-        Store.getState().searchDataLength
+        Store.getState().searchDataLength,
+        Store.getState().isKeywordValid
       ),
       queriesForGA: Store.getState().queriesForGA,
     });
@@ -147,8 +148,8 @@ class App extends React.Component {
    */
   submitSearchRequest(selectedFacet = '') {
     if (!this.state.searchKeyword) {
-      this.setState({ isKeywordValid: false });
       Actions.updateSelectedFacet(selectedFacet);
+      Actions.updateIsKeywordValid(false);
     } else {
       makeClientApiCall(this.state.searchKeyword, selectedFacet, 0,
         (searchResultsItems, resultLength) => {
@@ -237,7 +238,7 @@ class App extends React.Component {
    * @param {number} searchResultsLength
    * @return {object} object
    */
-  renderResults(searchKeyword, searchResultsArray, searchResultsLength) {
+  renderResults(searchKeyword, searchResultsArray, searchResultsLength, isKeywordValid) {
     return (
       <Results
         selectedTab={this.state.tabIdValue}
@@ -251,14 +252,14 @@ class App extends React.Component {
         resultsStart={this.state.resultsStart}
         queriesForGA={this.state.queriesForGA}
         searchBySelectedFacetFunction={this.searchBySelectedFacet}
+        isKeywordValid={isKeywordValid}
       />
     );
   }
 
   render() {
     const inputValue = this.state.searchKeyword || '';
-    const inputPlaceholder = (this.state.isKeywordValid) ?
-      'What would you like to find?' : 'Please enter a keyword';
+    const inputPlaceholder = 'What would you like to find?';
 
     return (
       <div id="nyplGlobalSearchApp" className="nyplGlobalSearchApp">

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -163,6 +163,7 @@ class App extends React.Component {
           });
 
           Actions.updateSearchKeyword(currentSearchKeyword);
+          Actions.updateIsKeywordValid(true);
           Actions.updateSearchData(searchResultsItems);
           Actions.updateSearchDataLength(resultLength);
           Actions.updateSelectedFacet(facet);
@@ -174,7 +175,7 @@ class App extends React.Component {
         },
         () => {
           Actions.updateSearchKeyword('');
-          Actions.updateIsKeywordValid(false);
+          Actions.updateIsKeywordValid(true);
           Actions.updateQueriesForGA({
             searchedFrom: 'betasearch',
             timestamp: new Date().getTime(),
@@ -230,13 +231,14 @@ class App extends React.Component {
 
 
   /**
-   * renderResults(searchKeyword, searchResultsArray, searchResultsLength)
+   * renderResults(searchKeyword, searchResultsArray, searchResultsLength, isKeywordValid)
    * The function renders the results of the search request.
    * If no search keyword input, it won't render anything and return null.
    *
    * @param {string} searchKeyword
    * @param {array} searchResultsArray
    * @param {number} searchResultsLength
+   * @param {boolean} isKeywordValid
    * @return {object} object
    */
   renderResults(searchKeyword, searchResultsArray, searchResultsLength, isKeywordValid) {

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -6,22 +6,22 @@ import {
 // Import components
 import { Header, navConfig } from '@nypl/dgx-header-component';
 import Footer from '@nypl/dgx-react-footer';
-import Results from '../Results/Results.jsx';
-import InputField from '../InputField/InputField.jsx';
-import SearchButton from '../SearchButton/SearchButton.jsx';
+import Results from '../Results/Results';
+import InputField from '../InputField/InputField';
+import SearchButton from '../SearchButton/SearchButton';
 
 // Import alt components
-import Store from '../../stores/Store.js';
-import Actions from '../../actions/Actions.js';
+import Store from '../../stores/Store';
+import Actions from '../../actions/Actions';
 
 // Import utilities
-import { makeClientApiCall } from '../../utils/MakeClientApiCall.js';
-import { createAppHistory } from '../../utils/SearchHistory.js';
-import { nativeGA } from '../../utils/GAUtils.js';
+import { makeClientApiCall } from '../../utils/MakeClientApiCall';
+import { createAppHistory } from '../../utils/SearchHistory';
+import { nativeGA } from '../../utils/GAUtils';
 
 const history = createAppHistory();
 
-history.listen(location => {
+history.listen((location) => {
   const {
     action,
     pathname,
@@ -31,7 +31,10 @@ history.listen(location => {
   const resultsStart = 0;
 
   if (action === 'POP') {
-    makeClientApiCall(searchKeyword, searchFacet, resultsStart,
+    makeClientApiCall(
+      searchKeyword,
+      searchFacet,
+      resultsStart,
       (searchResultsItems, resultLength) => {
         Actions.updateSearchKeyword(searchKeyword);
         Actions.updateSearchData(searchResultsItems);
@@ -50,7 +53,7 @@ history.listen(location => {
           searchedFrom: 'betasearch',
           timestamp: new Date().getTime(),
         });
-      }
+      },
     );
   }
 });
@@ -62,10 +65,9 @@ class App extends React.Component {
     this.state = _extend(
       {
         resultsComponentData: null,
-        isLoading: false,
         isGAQuerySent: false,
       },
-      Store.getState()
+      Store.getState(),
     );
 
     this.onChange = this.onChange.bind(this);
@@ -85,7 +87,7 @@ class App extends React.Component {
         Store.getState().searchKeyword,
         Store.getState().searchData,
         Store.getState().searchDataLength,
-        Store.getState().isKeywordValid
+        Store.getState().isKeywordValid,
       ),
     });
   }
@@ -103,14 +105,13 @@ class App extends React.Component {
   onChange() {
     // Updates the state with the new search data
     this.setState({
-      isLoading: false,
       searchKeyword: Store.getState().searchKeyword,
       selectedFacet: Store.getState().selectedFacet,
       resultsComponentData: this.renderResults(
         Store.getState().searchKeyword,
         Store.getState().searchData,
         Store.getState().searchDataLength,
-        Store.getState().isKeywordValid
+        Store.getState().isKeywordValid,
       ),
       queriesForGA: Store.getState().queriesForGA,
     });
@@ -152,7 +153,10 @@ class App extends React.Component {
       Actions.updateIsKeywordValid(false);
       Actions.updateSearchKeyword('');
     } else {
-      makeClientApiCall(this.state.searchKeyword, selectedFacet, 0,
+      makeClientApiCall(
+        this.state.searchKeyword,
+        selectedFacet,
+        0,
         (searchResultsItems, resultLength) => {
           const currentSearchKeyword = this.state.searchKeyword.trim() || '';
           const facet = selectedFacet;
@@ -180,7 +184,7 @@ class App extends React.Component {
             searchedFrom: 'betasearch',
             timestamp: new Date().getTime(),
           });
-        }
+        },
       );
     }
   }
@@ -224,7 +228,7 @@ class App extends React.Component {
           // as we don't reload the page after a search request
           setTimeout(() => { this.setState({ isGAQuerySent: false }); }, 200);
           this.submitSearchRequest(selectedFacet);
-        }
+        },
       );
     }
   }
@@ -294,13 +298,14 @@ class App extends React.Component {
                   />
                 </div>
                 <div className="gs-search-catalog-link-wrapper">
-                  <a className="gs-search-catalog-link"
+                  <a
+                    className="gs-search-catalog-link"
                     href={
-                      `https://browse.nypl.org/iii/encore/search/C__S${this.state.searchKeyword}__` +
-                      'Orightresult__U?lang=eng&suite=def'
+                      `https://browse.nypl.org/iii/encore/search/C__S${this.state.searchKeyword}__`
+                      + 'Orightresult__U?lang=eng&suite=def'
                     }
                   >
-                    Find books, music, or movies instead >
+                    {'Find books, music, or movies instead >'}
                   </a>
                 </div>
 

--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -37,6 +37,7 @@ history.listen((location) => {
       resultsStart,
       (searchResultsItems, resultLength) => {
         Actions.updateSearchKeyword(searchKeyword);
+        Actions.updateIsKeywordValid(true);
         Actions.updateSearchData(searchResultsItems);
         Actions.updateSearchDataLength(resultLength);
         Actions.updateSelectedFacet(searchFacet);
@@ -48,7 +49,7 @@ history.listen((location) => {
       },
       () => {
         Actions.updateSearchKeyword('');
-        Actions.updateIsKeywordValid(false);
+        Actions.updateIsKeywordValid(true);
         Actions.updateQueriesForGA({
           searchedFrom: 'betasearch',
           timestamp: new Date().getTime(),

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -243,7 +243,7 @@ class Results extends React.Component {
    * @return {object}
    */
   renderSeeMoreButton(remainingResults) {
-    if (this.props.amount < this.state.incrementResults) {
+    if (parseInt(this.props.amount, 10) < this.state.incrementResults) {
       return null;
     }
 
@@ -279,7 +279,7 @@ class Results extends React.Component {
    */
   renderResultsNumberSuggestion(resultsLength) {
     let resultsNumberSuggestion;
-    const textOfResult = this.props.amount === 1 ? 'result' : 'results';
+    const textOfResult = parseInt(this.props.amount, 10) === 1 ? 'result' : 'results';
     const resultMessageClass = (resultsLength === 0 || !this.props.isKeywordValid) ?
       'noResultMessage' : `${this.props.className}-length`;
 
@@ -361,7 +361,7 @@ class Results extends React.Component {
             </ol>
             {
               results.length % 10 === 0 &&
-              this.renderSeeMoreButton(Math.min(this.props.amount - results.length, 10))
+              this.renderSeeMoreButton(Math.min(parseInt(this.props.amount, 10) - results.length, 10))
             }
             <ReturnLink linkRoot="/search/apachesolr_search/" inputValue={inputValue} />
           </div>
@@ -376,7 +376,7 @@ Results.propTypes = {
   id: PropTypes.string,
   className: PropTypes.string,
   results: PropTypes.array,
-  amount: PropTypes.number,
+  amount: PropTypes.string,
   searchKeyword: PropTypes.string,
   resultsStart: PropTypes.number,
   selectedFacet: PropTypes.string,
@@ -391,7 +391,7 @@ Results.defaultProps = {
   id: 'results',
   className: 'results',
   results: [],
-  amount: 0,
+  amount: '0',
   searchKeyword: '',
   resultsStart: 0,
   selectedFacet: '',

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -34,6 +34,7 @@ class Results extends React.Component {
       searchResults: this.props.results,
       timeToLoadResults: new Date().getTime(),
       queriesForGA: this.props.queriesForGA,
+      isKeywordValid: this.props.isKeywordValid,
     };
 
     this.getList = this.getList.bind(this);
@@ -79,6 +80,7 @@ class Results extends React.Component {
       searchResults: Store.getState().searchData,
       timeToLoadResults: new Date().getTime(),
       queriesForGA: Store.getState().queriesForGA,
+      isKeywordValid: Store.getState().isKeywordValid,
     });
   }
 
@@ -284,7 +286,11 @@ class Results extends React.Component {
       'noResultMessage' : `${this.props.className}-length`;
 
     if (!this.props.searchKeyword) {
-      resultsNumberSuggestion = '';
+      if (!this.state.isKeywordValid) {
+        resultsNumberSuggestion = 'Please enter a keyword';
+      } else {
+        resultsNumberSuggestion = '';
+      }
     } else {
       resultsNumberSuggestion = (resultsLength === 0) ?
         'No results were found' :

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -441,26 +441,26 @@ class Results extends React.Component {
 }
 
 Results.propTypes = {
-  lang: PropTypes.string,
   id: PropTypes.string,
   className: PropTypes.string,
   results: PropTypes.arrayOf(PropTypes.object),
   amount: PropTypes.string,
   searchKeyword: PropTypes.string,
+  isKeywordValid: PropTypes.bool,
   resultsStart: PropTypes.number,
   selectedFacet: PropTypes.string,
-  queriesForGA: PropTypes.objectOf(PropTypes.object),
+  queriesForGA: PropTypes.objectOf(PropTypes.any),
   tabs: PropTypes.arrayOf(PropTypes.object),
   searchBySelectedFacetFunction: PropTypes.func.isRequired,
 };
 
 Results.defaultProps = {
-  lang: 'en',
   id: 'results',
   className: 'results',
   results: [],
   amount: '0',
   searchKeyword: '',
+  isKeywordValid: true,
   resultsStart: 0,
   selectedFacet: '',
   queriesForGA: {},

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -465,6 +465,7 @@ Results.defaultProps = {
   selectedFacet: '',
   queriesForGA: {},
   tabs: [],
+  searchBySelectedFacetFunction: () => {},
 };
 
 export default Results;

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -282,7 +282,7 @@ class Results extends React.Component {
   renderResultsNumberSuggestion(resultsLength) {
     let resultsNumberSuggestion;
     const textOfResult = this.props.amount === 1 ? 'result' : 'results';
-    const resultMessageClass = (resultsLength === 0) ?
+    const resultMessageClass = (resultsLength === 0 || !this.state.isKeywordValid) ?
       'noResultMessage' : `${this.props.className}-length`;
 
     if (!this.props.searchKeyword) {

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -34,7 +34,6 @@ class Results extends React.Component {
       searchResults: this.props.results,
       timeToLoadResults: new Date().getTime(),
       queriesForGA: this.props.queriesForGA,
-      isKeywordValid: this.props.isKeywordValid,
     };
 
     this.getList = this.getList.bind(this);
@@ -80,7 +79,6 @@ class Results extends React.Component {
       searchResults: Store.getState().searchData,
       timeToLoadResults: new Date().getTime(),
       queriesForGA: Store.getState().queriesForGA,
-      isKeywordValid: Store.getState().isKeywordValid,
     });
   }
 
@@ -282,13 +280,16 @@ class Results extends React.Component {
   renderResultsNumberSuggestion(resultsLength) {
     let resultsNumberSuggestion;
     const textOfResult = this.props.amount === 1 ? 'result' : 'results';
-    const resultMessageClass = (resultsLength === 0 || !this.state.isKeywordValid) ?
+    const resultMessageClass = (resultsLength === 0 || !this.props.isKeywordValid) ?
       'noResultMessage' : `${this.props.className}-length`;
 
     if (!this.props.searchKeyword) {
-      if (!this.state.isKeywordValid) {
+      if (!this.props.isKeywordValid) {
+        // Show 'Please enter a keyword' only if press tab or search button without a keyword
         resultsNumberSuggestion = 'Please enter a keyword';
       } else {
+        // If go to the root URL without a keyword for the first time,
+        // it will not show 'Please enter a keyword'
         resultsNumberSuggestion = '';
       }
     } else {

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -280,7 +280,7 @@ class Results extends React.Component {
   renderResultsNumberSuggestion(resultsLength) {
     let resultsNumberSuggestion;
     const textOfResult = parseInt(this.props.amount, 10) === 1 ? 'result' : 'results';
-    const resultMessageClass = (resultsLength === 0 || !this.props.isKeywordValid) ?
+    const resultMessageClass = (parseInt(resultsLength, 10) === 0 || !this.props.isKeywordValid) ?
       'noResultMessage' : `${this.props.className}-length`;
 
     if (!this.props.searchKeyword) {

--- a/src/app/stores/Store.js
+++ b/src/app/stores/Store.js
@@ -19,7 +19,7 @@ class SearchStore {
     this.on('init', () => {
       this.searchKeyword = '';
       this.searchData = [];
-      this.searchDataLength = 0;
+      this.searchDataLength = '0';
       this.isKeywordValid = true;
       this.selectedFacet = '';
       this.resultsStart = 0;

--- a/test/Results.test.js
+++ b/test/Results.test.js
@@ -10,156 +10,158 @@ describe('Results', () => {
     { anchor: 'Events', label: 'events_classes', resultSummarydisplayName: 'events' }
   ];
 
-  describe('if the user visits the main page without keyword as a pathname', () => {
-    let component;
+  describe('Search results summary', () => {
+    describe('if the user visits the main page without a keyword as the pathname', () => {
+      let component;
 
-    before(() => {
-      component  = shallow(<Results isKeywordValid={true} />);
+      before(() => {
+        component  = shallow(<Results isKeywordValid={true} />);
+      });
+
+      it('search results summary should be empty.', () => {
+        expect(component.find('#search-results-summary').text()).to.deep.equal('');
+      });
     });
 
-    it('search results summary should be empty.', () => {
-      expect(component.find('#search-results-summary').text()).to.deep.equal('');
-    });
-  });
+    describe('if the user requests searching wihtout a search keyword', () => {
+      let component;
 
-  describe('if the user requests search wihtout any search keyword', () => {
-    let component;
+      before(() => {
+        component = shallow(<Results isKeywordValid={false} />);
+      });
 
-    before(() => {
-      component = shallow(<Results isKeywordValid={false} />);
-    });
-
-    it('should show the message asking for a search keyword', () => {
-      expect(component.find('#search-results-summary').text())
-        .to.deep.equal('Please enter a keyword');
-    });
-  });
-
-  describe('if there are no results but there is a search keyword', () => {
-    let component;
-
-    before(() => {
-      component  = shallow(<Results tabs={tabs} searchKeyword={'jibberish'} results={[]} />);
+      it('should show the message asking for a search keyword', () => {
+        expect(component.find('#search-results-summary').text())
+          .to.deep.equal('Please enter a keyword');
+      });
     });
 
-    it('should render "No results were found.', () => {
-      expect(component.find('#search-results-summary').text()).to.deep.equal(
-        'No results were found'
-      );
-    });
-  });
+    describe('if there are no results but there is a search keyword', () => {
+      let component;
 
-  describe('if there is a search keyword and a facet other than "All" is selected, ' +
-    'yet there are no matching search results', () => {
-    let component;
+      before(() => {
+        component  = shallow(<Results tabs={tabs} searchKeyword={'jibberish'} results={[]} />);
+      });
 
-    before(() => {
-      component  = shallow(
-        <Results
-          tabs={tabs}
-          searchKeyword={'jibberish'}
-          selectedFacet={'events_classes'}
-          results={[]}
-        />);
+      it('should render "No results were found.', () => {
+        expect(component.find('#search-results-summary').text()).to.deep.equal(
+          'No results were found'
+        );
+      });
     });
 
-    it('should render "No results were found in selected_facet_name".', () => {
-      expect(component.find('#search-results-summary').text()).to.deep.equal(
-        'No results were found in events'
-      );
-    });
-  });
+    describe('if there is a search keyword and a facet other than "All" is selected, ' +
+      'yet there are no matching search results', () => {
+      let component;
 
-  describe('if there is a search keyword and the facet "All" is selected, ' +
-    'yet there are no search results', () => {
-    let component;
+      before(() => {
+        component  = shallow(
+          <Results
+            tabs={tabs}
+            searchKeyword={'jibberish'}
+            selectedFacet={'events_classes'}
+            results={[]}
+          />);
+      });
 
-    before(() => {
-      // When the selected facet is all, that means no selectedFacet value is passed to
-      // the component
-      component  = shallow(
-        <Results tabs={tabs} searchKeyword={'jibberish'} selectedFacet={''} results={[]} />
-      );
-    });
-
-    it('should render "No results were found".', () => {
-      expect(component.find('#search-results-summary').text()).to.deep.equal(
-        'No results were found'
-      );
-    });
-  });
-
-  describe('if more than 1 results are returned and a facet other than "All" is selected', () => {
-    let component;
-    const results = [{}, {}, {}];
-    const amount = results.length;
-
-    before(() => {
-      component = shallow(
-        <Results
-          tabs={tabs}
-          amount={amount}
-          searchKeyword={'okapi'}
-          selectedFacet={'articles_databases'}
-          results={results}
-        />
-      );
+      it('should render "No results were found in selected_facet_name".', () => {
+        expect(component.find('#search-results-summary').text()).to.deep.equal(
+          'No results were found in events'
+        );
+      });
     });
 
-    it('should render the proper summary for the results.', () => {
-      expect(component.find('#search-results-summary').text()).to.deep.equal(
-        'Found about 3 results for "okapi" in databases'
-      );
-    });
-  });
+    describe('if there is a search keyword and the facet "All" is selected, ' +
+      'yet there are no search results', () => {
+      let component;
 
-  describe('if more than 1 result are returned and the facet "All" is selected', () => {
-    let component;
-    const results = [{}, {}, {}];
-    const amount = results.length;
+      before(() => {
+        // When the selected facet is all, that means no selectedFacet value is passed to
+        // the component
+        component  = shallow(
+          <Results tabs={tabs} searchKeyword={'jibberish'} selectedFacet={''} results={[]} />
+        );
+      });
 
-    before(() => {
-      // When the selected facet is all, that means no selectedFacet value is passed to
-      // the component
-      component = shallow(
-        <Results
-          tabs={tabs}
-          amount={amount}
-          searchKeyword={'okapi'}
-          selectedFacet={''}
-          results={results}
-        />
-      );
+      it('should render "No results were found".', () => {
+        expect(component.find('#search-results-summary').text()).to.deep.equal(
+          'No results were found'
+        );
+      });
     });
 
-    it('should render the proper summary for the results.', () => {
-      expect(component.find('#search-results-summary').text()).to.deep.equal(
-        'Found about 3 results for "okapi"'
-      );
+    describe('if more than 1 results are returned and a facet other than "All" is selected', () => {
+      let component;
+      const results = [{}, {}, {}];
+      const amount = results.length;
+
+      before(() => {
+        component = shallow(
+          <Results
+            tabs={tabs}
+            amount={amount}
+            searchKeyword={'okapi'}
+            selectedFacet={'articles_databases'}
+            results={results}
+          />
+        );
+      });
+
+      it('should render the proper summary for the results.', () => {
+        expect(component.find('#search-results-summary').text()).to.deep.equal(
+          'Found about 3 results for "okapi" in databases'
+        );
+      });
     });
-  });
 
-  describe('if only 1 result is returned', () => {
-    let component;
-    const results = [{}];
-    const amount = results.length;
+    describe('if more than 1 result are returned and the facet "All" is selected', () => {
+      let component;
+      const results = [{}, {}, {}];
+      const amount = results.length;
 
-    before(() => {
-      component = shallow(
-        <Results
-          tabs={tabs}
-          amount={amount}
-          searchKeyword={'volcano'}
-          selectedFacet={'articles_databases'}
-          results={results}
-        />
-      );
+      before(() => {
+        // When the selected facet is all, that means no selectedFacet value is passed to
+        // the component
+        component = shallow(
+          <Results
+            tabs={tabs}
+            amount={amount}
+            searchKeyword={'okapi'}
+            selectedFacet={''}
+            results={results}
+          />
+        );
+      });
+
+      it('should render the proper summary for the results.', () => {
+        expect(component.find('#search-results-summary').text()).to.deep.equal(
+          'Found about 3 results for "okapi"'
+        );
+      });
     });
 
-    it('should render the proper summary for the 1 result.', () => {
-      expect(component.find('#search-results-summary').text()).to.deep.equal(
-        'Found about 1 result for "volcano" in databases'
-      );
+    describe('if only 1 result is returned', () => {
+      let component;
+      const results = [{}];
+      const amount = results.length;
+
+      before(() => {
+        component = shallow(
+          <Results
+            tabs={tabs}
+            amount={amount}
+            searchKeyword={'volcano'}
+            selectedFacet={'articles_databases'}
+            results={results}
+          />
+        );
+      });
+
+      it('should render the proper summary for the 1 result.', () => {
+        expect(component.find('#search-results-summary').text()).to.deep.equal(
+          'Found about 1 result for "volcano" in databases'
+        );
+      });
     });
   });
 });

--- a/test/Results.test.js
+++ b/test/Results.test.js
@@ -11,7 +11,7 @@ describe('Results', () => {
   ];
 
   describe('Search results summary', () => {
-    describe('if the user visits the main page without a keyword as the pathname', () => {
+    describe('if the user visits the main paqgie without a keyword as the pathname', () => {
       let component;
 
       before(() => {
@@ -20,6 +20,10 @@ describe('Results', () => {
 
       it('search results summary should be empty.', () => {
         expect(component.find('#search-results-summary').text()).to.deep.equal('');
+        expect(component.find('#search-results-summary').hasClass('noResultMessage'))
+          .to.equal(true);
+        expect(component.find('#search-results-summary').hasClass('results-length'))
+          .to.equal(false);
       });
     });
 
@@ -33,6 +37,10 @@ describe('Results', () => {
       it('should show the message asking for a search keyword', () => {
         expect(component.find('#search-results-summary').text())
           .to.deep.equal('Please enter a keyword');
+        expect(component.find('#search-results-summary').hasClass('noResultMessage'))
+          .to.equal(true);
+        expect(component.find('#search-results-summary').hasClass('results-length'))
+          .to.equal(false);
       });
     });
 
@@ -40,13 +48,19 @@ describe('Results', () => {
       let component;
 
       before(() => {
-        component  = shallow(<Results tabs={tabs} searchKeyword={'jibberish'} results={[]} />);
+        component  = shallow(
+          <Results tabs={tabs} searchKeyword={'jibberish'} results={[]} isKeywordValid={true} />
+        );
       });
 
       it('should render "No results were found.', () => {
         expect(component.find('#search-results-summary').text()).to.deep.equal(
           'No results were found'
         );
+        expect(component.find('#search-results-summary').hasClass('noResultMessage'))
+          .to.equal(true);
+        expect(component.find('#search-results-summary').hasClass('results-length'))
+          .to.equal(false);
       });
     });
 
@@ -61,6 +75,7 @@ describe('Results', () => {
             searchKeyword={'jibberish'}
             selectedFacet={'events_classes'}
             results={[]}
+            isKeywordValid={true}
           />);
       });
 
@@ -68,6 +83,10 @@ describe('Results', () => {
         expect(component.find('#search-results-summary').text()).to.deep.equal(
           'No results were found in events'
         );
+        expect(component.find('#search-results-summary').hasClass('noResultMessage'))
+          .to.equal(true);
+        expect(component.find('#search-results-summary').hasClass('results-length'))
+          .to.equal(false);
       });
     });
 
@@ -79,7 +98,13 @@ describe('Results', () => {
         // When the selected facet is all, that means no selectedFacet value is passed to
         // the component
         component  = shallow(
-          <Results tabs={tabs} searchKeyword={'jibberish'} selectedFacet={''} results={[]} />
+          <Results
+            tabs={tabs}
+            searchKeyword={'jibberish'}
+            selectedFacet={''}
+            results={[]}
+            isKeywordValid={true}
+          />
         );
       });
 
@@ -87,13 +112,17 @@ describe('Results', () => {
         expect(component.find('#search-results-summary').text()).to.deep.equal(
           'No results were found'
         );
+        expect(component.find('#search-results-summary').hasClass('noResultMessage'))
+          .to.equal(true);
+        expect(component.find('#search-results-summary').hasClass('results-length'))
+          .to.equal(false);
       });
     });
 
     describe('if more than 1 results are returned and a facet other than "All" is selected', () => {
       let component;
       const results = [{}, {}, {}];
-      const amount = results.length;
+      const amount = results.length.toString();
 
       before(() => {
         component = shallow(
@@ -103,6 +132,7 @@ describe('Results', () => {
             searchKeyword={'okapi'}
             selectedFacet={'articles_databases'}
             results={results}
+            isKeywordValid={true}
           />
         );
       });
@@ -111,13 +141,17 @@ describe('Results', () => {
         expect(component.find('#search-results-summary').text()).to.deep.equal(
           'Found about 3 results for "okapi" in databases'
         );
+        expect(component.find('#search-results-summary').hasClass('noResultMessage'))
+          .to.equal(false);
+        expect(component.find('#search-results-summary').hasClass('results-length'))
+          .to.equal(true);
       });
     });
 
     describe('if more than 1 result are returned and the facet "All" is selected', () => {
       let component;
       const results = [{}, {}, {}];
-      const amount = results.length;
+      const amount = results.length.toString();
 
       before(() => {
         // When the selected facet is all, that means no selectedFacet value is passed to
@@ -129,6 +163,7 @@ describe('Results', () => {
             searchKeyword={'okapi'}
             selectedFacet={''}
             results={results}
+            isKeywordValid={true}
           />
         );
       });
@@ -137,6 +172,8 @@ describe('Results', () => {
         expect(component.find('#search-results-summary').text()).to.deep.equal(
           'Found about 3 results for "okapi"'
         );
+        expect(component.find('#search-results-summary').hasClass('noResultMessage')).to.equal(false);
+        expect(component.find('#search-results-summary').hasClass('results-length')).to.equal(true);
       });
     });
 
@@ -153,6 +190,7 @@ describe('Results', () => {
             searchKeyword={'volcano'}
             selectedFacet={'articles_databases'}
             results={results}
+            isKeywordValid={true}
           />
         );
       });
@@ -161,6 +199,8 @@ describe('Results', () => {
         expect(component.find('#search-results-summary').text()).to.deep.equal(
           'Found about 1 result for "volcano" in databases'
         );
+        expect(component.find('#search-results-summary').hasClass('noResultMessage')).to.equal(false);
+        expect(component.find('#search-results-summary').hasClass('results-length')).to.equal(true);
       });
     });
   });

--- a/test/Results.test.js
+++ b/test/Results.test.js
@@ -10,15 +10,28 @@ describe('Results', () => {
     { anchor: 'Events', label: 'events_classes', resultSummarydisplayName: 'events' }
   ];
 
-  describe('if there are no results and no search keyword', () => {
+  describe('if the user visits the main page without keyword as a pathname', () => {
     let component;
 
     before(() => {
-      component  = shallow(<Results />);
+      component  = shallow(<Results isKeywordValid={true} />);
     });
 
     it('search results summary should be empty.', () => {
       expect(component.find('#search-results-summary').text()).to.deep.equal('');
+    });
+  });
+
+  describe('if the user requests search wihtout any search keyword', () => {
+    let component;
+
+    before(() => {
+      component = shallow(<Results isKeywordValid={false} />);
+    });
+
+    it('should show the message asking for a search keyword', () => {
+      expect(component.find('#search-results-summary').text())
+        .to.deep.equal('Please enter a keyword');
     });
   });
 


### PR DESCRIPTION
This PR adds the instruction message `Please enter a search keyword` if the user didn't enter a search keyword and press either the search button or a facet tab.

The message will be shown at the same place of results summary. In fact, they share the same HTML element.

This PR also lints  Application.jsx and Results.jsx.

Note the base of this PR is `da_single_source_tabs` because I use the linted file of Results.jsx from @danamansana 's feature branch.
