### PR TITLE
Removed the function for parsing snippet. It is not needed anymore.

### DIFF
--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -98,7 +98,7 @@ class Results extends React.Component {
         ref={`result-${index}`}
         title={item.title}
         link={this.transformHttpsToHttp(item.link)}
-        snippet={this.parseSnippet(item.snippet)}
+        snippet={item.snippet}
         thumbnailSrc={item.thumbnailSrc}
         label={item.label}
         className={`${this.props.className}Item`}
@@ -176,28 +176,6 @@ class Results extends React.Component {
     );
 
     this.moveFocusToNextPage(originalResultsStart, 0);
-  }
-
-  /**
-   * parseSnippet(snippetText)
-   * The function converts a string to an array
-   * if the separator pattern is found in the string.
-   * If a value is found in index 1 of the array,
-   * return that value else the original snippetText
-   * passed.
-   */
-  parseSnippet(snippetText) {
-    if (!snippetText && typeof snippetText !== 'string') {
-      return '';
-    }
-
-    const faultyJsonArray = snippetText.trim().split('}}]]');
-
-    if (faultyJsonArray.length > 1) {
-      return faultyJsonArray[1];
-    }
-
-    return snippetText;
   }
 
   /**


### PR DESCRIPTION
This PR removes the function that parse the snippet. Before, we need this function to correct the odd contents from Refinery. Since we are talking to Google API directly now, we don't need this function anymore.

I have checked the three links that were reported with this problem before, but seem all are ok now.

- https://www.nypl.org/searchbeta/tony%20ageh/
- https://www.nypl.org/searchbeta/welcome%20winnie/
- https://www.nypl.org/searchbeta/floor%20plan/

Please check the ticket and merged PR for further references.
https://jira.nypl.org/browse/WWW-503
https://github.com/NYPL/dgx-global-search/pull/16