### PR TITLE
Move modeling functions out of results jsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.0.2
+#### Updated
+- Updadting Results.jsx to move the functions rerlated to modeling data out of it.
+
 ### v1.0.1
 #### Updated
 - Updating @nypl/dgx-header-component to 2.4.19

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -97,7 +97,7 @@ class Results extends React.Component {
         index={index}
         ref={`result-${index}`}
         title={item.title}
-        link={this.transformHttpsToHttp(item.link)}
+        link={item.link}
         snippet={this.parseSnippet(item.snippet)}
         thumbnailSrc={item.thumbnailSrc}
         label={item.label}
@@ -198,32 +198,6 @@ class Results extends React.Component {
     }
 
     return snippetText;
-  }
-
-  /**
-   * transformHttpsToHttp(link)
-   * The function converts certain NYPL subdomains to http
-   * to prevent an error when that site does not have SSL enabled.
-   */
-  transformHttpsToHttp(link) {
-    if (!link) {
-      return '';
-    }
-
-    const transformationRequired =
-      link.includes('//digital.nypl.org') ||
-      link.includes('//menus.nypl.org') ||
-      link.includes('//exhibitions.nypl.org') ||
-      link.includes('//static.nypl.org') ||
-      link.includes('//static.nypl.org/exhibitions') ||
-      link.includes('//web-static.nypl.org/exhibitions') ||
-      link.includes('//web-static.nypl.org');
-
-    if (link && transformationRequired) {
-      return link.replace('https:', 'http:');
-    }
-
-    return link;
   }
 
   selectedTab(tabIdValue) {

--- a/src/app/stores/Store.js
+++ b/src/app/stores/Store.js
@@ -1,5 +1,5 @@
 import Actions from '../actions/Actions.js';
-import { filterNames } from '../utils/FilterNames.js';
+import filterNames from '../utils/FilterNames.js';
 import alt from 'dgx-alt-center';
 
 class SearchStore {

--- a/src/app/utils/ExecptionalDomains.js
+++ b/src/app/utils/ExecptionalDomains.js
@@ -1,0 +1,13 @@
+// If the URL of a result item is in one of these domains,
+// it should not be converted to begin with "https"
+const execptionalDomains = [
+  '//digital.nypl.org',
+  '//menus.nypl.org',
+  '//exhibitions.nypl.org',
+  '//static.nypl.org',
+  '//static.nypl.org/exhibitions',
+  '//web-static.nypl.org/exhibitions',
+  '//web-static.nypl.org',
+];
+
+export { execptionalDomains };

--- a/src/app/utils/ExecptionalDomains.js
+++ b/src/app/utils/ExecptionalDomains.js
@@ -10,4 +10,4 @@ const execptionalDomains = [
   '//web-static.nypl.org',
 ];
 
-export { execptionalDomains };
+export default execptionalDomains;

--- a/src/app/utils/FilterNames.js
+++ b/src/app/utils/FilterNames.js
@@ -53,6 +53,6 @@ const filterNames = [
     label: 'locations',
     resultSummarydisplayName: 'locations',
   }
-]
+];
 
 export { filterNames };

--- a/src/app/utils/FilterNames.js
+++ b/src/app/utils/FilterNames.js
@@ -52,7 +52,7 @@ const filterNames = [
     value: 'locations',
     label: 'locations',
     resultSummarydisplayName: 'locations',
-  }
+  },
 ];
 
-export { filterNames };
+export default filterNames;

--- a/src/app/utils/SearchModel.js
+++ b/src/app/utils/SearchModel.js
@@ -1,6 +1,3 @@
-import { filterNames } from './FilterNames.js';
-import { execptionalDomains } from './ExecptionalDomains.js';
-
 // Import libraries
 import {
   map as _map,
@@ -8,6 +5,8 @@ import {
   isEmpty as _isEmpty,
   find as _find,
 } from 'underscore';
+import filterNames from './FilterNames';
+import execptionalDomains from './ExecptionalDomains';
 
 /**
  * fetchResultLength(data)
@@ -36,9 +35,7 @@ const fetchResultLength = (data) => {
  *
  * @return {Array}
  */
-const fetchSearchFacetsList = () => {
-  return filterNames;
-}
+const fetchSearchFacetsList = () => filterNames;
 
 /**
  * extractSearchElements(requestCombo)
@@ -67,7 +64,7 @@ const extractSearchElements = (requestCombo) => {
   };
 };
 
-const displayName = (name) => filterNames.find(obj => obj.value === name).anchor
+const displayName = name => filterNames.find(obj => obj.value === name).anchor;
 /**
  * fetchDisplayName(labelsArray, searchRequest)
  * The function returns the display name of the item.
@@ -91,20 +88,16 @@ const fetchDisplayName = (labelsArray, searchRequest) => {
     return '';
   }
 
-  const displayNameArray = _map(labelsArray, (label) => {
-    return {
-      name: label.name || '',
-    };
-  });
+  const displayNameArray = _map(labelsArray, label => ({ name: label.name || '' }));
 
-  const searchFacet = extractSearchElements(searchRequest).searchFacet;
+  const {
+    searchFacet,
+  } = extractSearchElements(searchRequest);
 
   if (!searchFacet) {
     name = displayNameArray[0].name;
   } else {
-    name = _find(displayNameArray, (item) =>
-      item.name === searchFacet
-    ).name;
+    name = _find(displayNameArray, item => item.name === searchFacet).name;
   }
 
   return displayName(name || '');
@@ -125,28 +118,28 @@ const fetchDisplayName = (labelsArray, searchRequest) => {
  * @param {String} string
  * @return {String}
  */
-const stripPossibleHTMLTag = (string) =>
-  string.replace(/&lt;[^(&gt;)]+?&gt;/g, '').replace(/&lt;.*/, '');
+const stripPossibleHTMLTag = string => string
+  .replace(/&lt;[^(&gt;)]+?&gt;/g, '').replace(/&lt;.*/, '');
 
 
 /**
- * secureHttpsProtocol(url, execptionalDomains)
+ * secureHttpsProtocol(url, domains)
  * The function gets the URL that begins with http and converts it to begin with https,
  * unless if the URL belongs to one of the execptional domains.
  *
  * @param {String} url
- * @param {Array} execptionalDomains
+ * @param {Array} domains
  * @return {String}
  */
-const secureHttpsProtocol = (url, execptionalDomains) => {
-  if (execptionalDomains.some((domainString) => url.includes(domainString))) {
+const secureHttpsProtocol = (url, domains) => {
+  if (domains.some(domain => url.includes(domain))) {
     return url;
   }
 
   const newUrl = url.replace(/^http:\/\//i, 'https://');
 
   return newUrl;
-}
+};
 
 /**
  * fetchItemFeature(item, feature)
@@ -158,25 +151,21 @@ const secureHttpsProtocol = (url, execptionalDomains) => {
  * @param {String} SearchRequest
  * @return {String}
  */
-const fetchItemFeature = (item, feature) => {
-  return item[feature] || '';
-};
+const fetchItemFeature = (item, feature) => (item[feature] || '');
 
-const getNestedData = (array, item) => {
-  return array.reduce((acc, el) => (acc[el] || ''), item)
-}
+const getNestedData = (array, item) => array.reduce((acc, el) => (acc[el] || ''), item);
 
 const logThumbnail = (item) => {
-  let thumbnails = getNestedData(['pagemap', 'cse_thumbnail'], item);
+  const thumbnails = getNestedData(['pagemap', 'cse_thumbnail'], item);
   if (thumbnails.length && thumbnails.length > 1) {
     console.log('item with multiple thumbnails: ', JSON.stringify(item));
   }
-}
+};
 
 const fetchThumbnail = (item) => {
   logThumbnail(item);
-  return getNestedData(['pagemap', 'cse_thumbnail', 0, 'src'], item)
-}
+  return getNestedData(['pagemap', 'cse_thumbnail', 0, 'src'], item);
+};
 
 /**
  * fetchItem(item, searchRequest)
@@ -228,7 +217,7 @@ const fetchItem = (item, searchRequest) => {
  */
 const fetchResultItems = (data, searchRequest = '') => {
   try {
-    return _map(data.items, (item) => (fetchItem(item, searchRequest)));
+    return _map(data.items, item => fetchItem(item, searchRequest));
   } catch (e) {
     console.log(e);
     return [];

--- a/src/app/utils/SearchModel.js
+++ b/src/app/utils/SearchModel.js
@@ -1,4 +1,5 @@
 import { filterNames } from './FilterNames.js';
+import { execptionalDomains } from './ExecptionalDomains.js';
 
 // Import libraries
 import {
@@ -129,14 +130,23 @@ const stripPossibleHTMLTag = (string) =>
 
 
 /**
- * secureHttpsProtocol(url)
- * The function gets the urls that begin with http and converts them to begin with https.
+ * secureHttpsProtocol(url, execptionalDomains)
+ * The function gets the URL that begins with http and converts it to begin with https,
+ * unless if the URL belongs to one of the execptional domains.
  *
- * @param {String} string
+ * @param {String} url
+ * @param {Array} execptionalDomains
  * @return {String}
  */
-const secureHttpsProtocol = (url) =>
-  url.replace(/^http:\/\//i, 'https://');
+const secureHttpsProtocol = (url, execptionalDomains) => {
+  if (execptionalDomains.some((domainString) => url.includes(domainString))) {
+    return url;
+  }
+
+  const newUrl = url.replace(/^http:\/\//i, 'https://');
+
+  return newUrl;
+}
 
 /**
  * fetchItemFeature(item, feature)
@@ -198,7 +208,7 @@ const fetchItem = (item, searchRequest) => {
 
   return {
     title: modeledTitle,
-    link: secureHttpsProtocol(fetchItemFeature(item, 'link')),
+    link: secureHttpsProtocol(fetchItemFeature(item, 'link'), execptionalDomains),
     snippet: modeledSnippet,
     thumbnailSrc: fetchThumbnail(item),
     label: fetchDisplayName(item.labels, searchRequest),

--- a/test/SearchModel.test.js
+++ b/test/SearchModel.test.js
@@ -39,7 +39,7 @@ describe('fetchResultItems', () => {
     'undefined or null.',
     () => {
       expect(fetchResultItems(testData.contentWithHTMLTags)).to.deep.equal(
-        matchedResults.ItemWithExhibitionLabel
+        matchedResults.itemWithExhibitionLabel
       );
     }
   );
@@ -47,27 +47,39 @@ describe('fetchResultItems', () => {
   it('should return an item with the matched label with search facet.',
     () => {
       expect(fetchResultItems(testData.contentWithHTMLTags, 'apple more:exhibitions')
-      ).to.deep.equal(matchedResults.ItemWithExhibitionLabel);
+      ).to.deep.equal(matchedResults.itemWithExhibitionLabel);
     }
   );
 
   it('should return an item without HTML tags in its title and snippet.',
     () => {
       expect(fetchResultItems(testData.contentWithHTMLTags, 'apple more:exhibitions')
-      ).to.deep.equal(matchedResults.ItemWithExhibitionLabel);
+      ).to.deep.equal(matchedResults.itemWithExhibitionLabel);
     }
   );
 
   it('should return an item with correct attributes.',
     () => {
       expect(fetchResultItems(testData.contentWithHTMLTags, 'apple more:exhibitions')
-      ).to.deep.equal(matchedResults.ItemWithExhibitionLabel);
+      ).to.deep.equal(matchedResults.itemWithExhibitionLabel);
     }
   );
+
+  it('should return the converted link of a result item to start with "https" instead of "http".',
+    () => {
+      expect(fetchResultItems(testData.contentWithChangeableHttpLink, 'apple more:exhibitions'))
+        .to.deep.equal(matchedResults.itemWithExhibitionLabel);
+    });
+
+  it('should preserve the link of a result item to start with "http" if its domain is specified' +
+    ' as an execption.', () => {
+      expect(fetchResultItems(testData.contentWithUnchangeableHttpLink, 'apple more:exhibitions'))
+        .to.deep.equal(matchedResults.itemWithUnchangeableLink);
+    });
 });
 
 describe('fetchSearchFacetsList', () => {
-  it('should return a preset facet array if data is undefined or null', () => {
+  it('should return a preset facet array if data is undefined or null.', () => {
     expect(fetchSearchFacetsList()).to.deep.equal(presetFacets);
   });
 });

--- a/test/SearchModelTestExampleData.js
+++ b/test/SearchModelTestExampleData.js
@@ -25,9 +25,9 @@ const testData = {
             }
           ]
         },
-        snippet: 'Jun 23, 2016 ... &lt;i&gt;SimplyE requires an Apple ID&lt;/i&gt; and a device with iOS8 or' +
-          'higher in order to download &lt;br&gt;the SimplyE app. iPad, iPad 2, iPad Air, iPad mini' +
-          'iOS 8+ ...&lt;/div',
+        snippet: 'Jun 23, 2016 ... &lt;i&gt;SimplyE requires an Apple ID&lt;/i&gt; and a device ' +
+          'with iOS8 or higher in order to download &lt;br&gt;the SimplyE app. iPad, iPad 2, '+
+          'iPad Air, iPad mini iOS 8+ ...&lt;/div',
         'thumbnail-url': 'https://encrypted-tbn3.gstatic.com/images?q=tbn:' +
           'ANd9GcScCym1VJKFD1kWJG7Pl4hwD0PaKv2iLi8FfV4g2z4J7fg0EN_MnqPaXqJM',
         labels: [
@@ -59,9 +59,9 @@ const testData = {
             }
           ]
         },
-        snippet: 'Jun 23, 2016 ... &lt;i&gt;SimplyE requires an Apple ID&lt;/i&gt; and a device with iOS8 or' +
-          'higher in order to download &lt;br&gt;the SimplyE app. iPad, iPad 2, iPad Air, iPad mini' +
-          'iOS 8+ ...&lt;/div',
+        snippet: 'Jun 23, 2016 ... &lt;i&gt;SimplyE requires an Apple ID&lt;/i&gt; and a device ' +
+          'with iOS8 or higher in order to download &lt;br&gt;the SimplyE app. iPad, iPad 2, '+
+          'iPad Air, iPad mini iOS 8+ ...&lt;/div',
         'thumbnail-url': 'https://encrypted-tbn3.gstatic.com/images?q=tbn:' +
           'ANd9GcScCym1VJKFD1kWJG7Pl4hwD0PaKv2iLi8FfV4g2z4J7fg0EN_MnqPaXqJM',
         labels: [
@@ -93,9 +93,9 @@ const testData = {
             }
           ]
         },
-        snippet: 'Jun 23, 2016 ... &lt;i&gt;SimplyE requires an Apple ID&lt;/i&gt; and a device with iOS8 or' +
-          'higher in order to download &lt;br&gt;the SimplyE app. iPad, iPad 2, iPad Air, iPad mini' +
-          'iOS 8+ ...&lt;/div',
+        snippet: 'Jun 23, 2016 ... &lt;i&gt;SimplyE requires an Apple ID&lt;/i&gt; and a device ' +
+          'with iOS8 or higher in order to download &lt;br&gt;the SimplyE app. iPad, iPad 2, '+
+          'iPad Air, iPad mini iOS 8+ ...&lt;/div',
         'thumbnail-url': 'https://encrypted-tbn3.gstatic.com/images?q=tbn:' +
           'ANd9GcScCym1VJKFD1kWJG7Pl4hwD0PaKv2iLi8FfV4g2z4J7fg0EN_MnqPaXqJM',
         labels: [
@@ -131,8 +131,8 @@ const matchedResults = {
     {
       title: 'Get Started with SimplyE for Apple iOS',
       link: 'https://gethelp.nypl.org/customer/portal/articles/2214923',
-      snippet: 'Jun 23, 2016 ... SimplyE requires an Apple ID and a device with iOS8 or' +
-        'higher in order to download the SimplyE app. iPad, iPad 2, iPad Air, iPad mini' +
+      snippet: 'Jun 23, 2016 ... SimplyE requires an Apple ID and a device with iOS8 or ' +
+        'higher in order to download the SimplyE app. iPad, iPad 2, iPad Air, iPad mini ' +
         'iOS 8+ ...',
       thumbnailSrc: 'https://encrypted-tbn3.gstatic.com/images?q=tbn:' +
         'ANd9GcScCym1VJKFD1kWJG7Pl4hwD0PaKv2iLi8FfV4g2z4J7fg0EN_MnqPaXqJM',
@@ -143,8 +143,8 @@ const matchedResults = {
     {
       title: 'Get Started with SimplyE for Apple iOS',
       link: 'http://exhibitions.nypl.org/biblion/worldsfair/gallery/gallery-aquacade',
-      snippet: 'Jun 23, 2016 ... SimplyE requires an Apple ID and a device with iOS8 or' +
-        'higher in order to download the SimplyE app. iPad, iPad 2, iPad Air, iPad mini' +
+      snippet: 'Jun 23, 2016 ... SimplyE requires an Apple ID and a device with iOS8 or ' +
+        'higher in order to download the SimplyE app. iPad, iPad 2, iPad Air, iPad mini ' +
         'iOS 8+ ...',
       thumbnailSrc: 'https://encrypted-tbn3.gstatic.com/images?q=tbn:' +
         'ANd9GcScCym1VJKFD1kWJG7Pl4hwD0PaKv2iLi8FfV4g2z4J7fg0EN_MnqPaXqJM',

--- a/test/SearchModelTestExampleData.js
+++ b/test/SearchModelTestExampleData.js
@@ -1,4 +1,4 @@
-import { filterNames } from '../src/app/utils/FilterNames.js';
+import filterNames from '../src/app/utils/FilterNames.js';
 
 const testData = {
   noItem: {

--- a/test/SearchModelTestExampleData.js
+++ b/test/SearchModelTestExampleData.js
@@ -47,6 +47,74 @@ const testData = {
       },
     ],
   },
+  contentWithChangeableHttpLink: {
+    items: [
+      {
+        title: 'Get Started with SimplyE for Apple &lt;span&gt;iOS&lt;/span&gt;',
+        link: 'http://gethelp.nypl.org/customer/portal/articles/2214923',
+        pagemap: {
+          cse_thumbnail: [
+            { src: 'https://encrypted-tbn3.gstatic.com/images?q=tbn:' +
+              'ANd9GcScCym1VJKFD1kWJG7Pl4hwD0PaKv2iLi8FfV4g2z4J7fg0EN_MnqPaXqJM'
+            }
+          ]
+        },
+        snippet: 'Jun 23, 2016 ... &lt;i&gt;SimplyE requires an Apple ID&lt;/i&gt; and a device with iOS8 or' +
+          'higher in order to download &lt;br&gt;the SimplyE app. iPad, iPad 2, iPad Air, iPad mini' +
+          'iOS 8+ ...&lt;/div',
+        'thumbnail-url': 'https://encrypted-tbn3.gstatic.com/images?q=tbn:' +
+          'ANd9GcScCym1VJKFD1kWJG7Pl4hwD0PaKv2iLi8FfV4g2z4J7fg0EN_MnqPaXqJM',
+        labels: [
+          {
+            name: 'exhibitions',
+            displayName: 'Exhibitions',
+          },
+          {
+            name: 'digital_collections',
+            displayName: 'Digital Collections',
+          },
+          {
+            name: 'audio_video',
+            displayName: 'Audio/Video',
+          },
+        ],
+      },
+    ],
+  },
+  contentWithUnchangeableHttpLink: {
+    items: [
+      {
+        title: 'Get Started with SimplyE for Apple &lt;span&gt;iOS&lt;/span&gt;',
+        link: 'http://exhibitions.nypl.org/biblion/worldsfair/gallery/gallery-aquacade',
+        pagemap: {
+          cse_thumbnail: [
+            { src: 'https://encrypted-tbn3.gstatic.com/images?q=tbn:' +
+              'ANd9GcScCym1VJKFD1kWJG7Pl4hwD0PaKv2iLi8FfV4g2z4J7fg0EN_MnqPaXqJM'
+            }
+          ]
+        },
+        snippet: 'Jun 23, 2016 ... &lt;i&gt;SimplyE requires an Apple ID&lt;/i&gt; and a device with iOS8 or' +
+          'higher in order to download &lt;br&gt;the SimplyE app. iPad, iPad 2, iPad Air, iPad mini' +
+          'iOS 8+ ...&lt;/div',
+        'thumbnail-url': 'https://encrypted-tbn3.gstatic.com/images?q=tbn:' +
+          'ANd9GcScCym1VJKFD1kWJG7Pl4hwD0PaKv2iLi8FfV4g2z4J7fg0EN_MnqPaXqJM',
+        labels: [
+          {
+            name: 'exhibitions',
+            displayName: 'Exhibitions',
+          },
+          {
+            name: 'digital_collections',
+            displayName: 'Digital Collections',
+          },
+          {
+            name: 'audio_video',
+            displayName: 'Audio/Video',
+          },
+        ],
+      },
+    ],
+  },
 };
 
 const matchedResults = {
@@ -59,10 +127,22 @@ const matchedResults = {
       label: '',
     },
   ],
-  ItemWithExhibitionLabel: [
+  itemWithExhibitionLabel: [
     {
       title: 'Get Started with SimplyE for Apple iOS',
       link: 'https://gethelp.nypl.org/customer/portal/articles/2214923',
+      snippet: 'Jun 23, 2016 ... SimplyE requires an Apple ID and a device with iOS8 or' +
+        'higher in order to download the SimplyE app. iPad, iPad 2, iPad Air, iPad mini' +
+        'iOS 8+ ...',
+      thumbnailSrc: 'https://encrypted-tbn3.gstatic.com/images?q=tbn:' +
+        'ANd9GcScCym1VJKFD1kWJG7Pl4hwD0PaKv2iLi8FfV4g2z4J7fg0EN_MnqPaXqJM',
+      label: 'Exhibitions',
+    },
+  ],
+  itemWithUnchangeableLink: [
+    {
+      title: 'Get Started with SimplyE for Apple iOS',
+      link: 'http://exhibitions.nypl.org/biblion/worldsfair/gallery/gallery-aquacade',
       snippet: 'Jun 23, 2016 ... SimplyE requires an Apple ID and a device with iOS8 or' +
         'higher in order to download the SimplyE app. iPad, iPad 2, iPad Air, iPad mini' +
         'iOS 8+ ...',


### PR DESCRIPTION
This PR moves the function of `transformHttpsToHttp` out of `Results.jsx`.

The function should be a feature of the function of `secureHttpsProtocol` in `SearchModel.js`. `secureHttpsProtocol` converts the links of results items to start with `https` if they originally start with `http`. However, `transformHttpsToHttp` pointed out there are some domains shouldn't be converted. So now `secureHttpsProtocol` has the feature to check now. Please see line 134-137 in `SearchModel.js`.

The list of the unconvertible domains is in `src/app/utils/ExecptionalDomains.js`.

The PR also adds the related tests and lints related files.