### PR TITLE
Fixed see more button render issues and converte amount from string t…

### DIFF
--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -225,17 +225,8 @@ class Results extends React.Component {
    */
   renderSeeMoreButton(remainingResults) {
     const {
-      amount,
       id,
     } = this.props;
-
-    const {
-      incrementResults,
-    } = this.state;
-
-    if (parseInt(amount, 10) < incrementResults) {
-      return null;
-    }
 
     if (remainingResults <= 0) {
       return (
@@ -263,7 +254,7 @@ class Results extends React.Component {
    * renderResultsNumberSuggestion(resultsLength)
    * Renders the <p> for displaying results summary.
    *
-   * @param {string} resultsLength - the amount of the total result items
+   * @param {number} resultsLength - the amount of the total result items
    * @return {HTML Element} p
    */
   renderResultsNumberSuggestion(resultsLength) {
@@ -281,8 +272,11 @@ class Results extends React.Component {
     } = this.state;
 
     let resultsNumberSuggestion;
-    const textOfResult = parseInt(amount, 10) === 1 ? 'result' : 'results';
-    const resultMessageClass = (parseInt(resultsLength, 10) === 0 || !isKeywordValid)
+    // Converts the string of amount into interger
+    // We need to remove the possible thousands separators first
+    const amountInt = parseInt(amount.replace(/,/g, ''), 10);
+    const textOfResult = amountInt === 1 ? 'result' : 'results';
+    const resultMessageClass = (resultsLength === 0 || !isKeywordValid)
       ? 'noResultMessage' : `${className}-length`;
 
     if (!searchKeyword) {
@@ -348,6 +342,9 @@ class Results extends React.Component {
 
     const results = this.getList(searchResults);
     const inputValue = searchKeyword || '';
+    // Converts the string of amount into interger
+    // We need to remove the possible thousands separators first
+    const amountInt = parseInt(amount.replace(/,/g, ''), 10);
 
     return (
       <div className={`${className}-wrapper`}>
@@ -381,7 +378,7 @@ class Results extends React.Component {
             </ol>
             {
               results.length % 10 === 0
-              && this.renderSeeMoreButton(Math.min(parseInt(amount, 10) - results.length, 10))
+              && this.renderSeeMoreButton(Math.min(amountInt - results.length, 10))
             }
             <ReturnLink linkRoot="/search/apachesolr_search/" inputValue={inputValue} />
           </div>

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -226,7 +226,20 @@ class Results extends React.Component {
   renderSeeMoreButton(remainingResults) {
     const {
       id,
+      amount,
     } = this.props;
+
+    const {
+      incrementResults,
+    } = this.state;
+
+    // Converts the string of amount into integer
+    // We need to remove the possible thousands separators first
+    const amountInt = parseInt(amount.replace(/[^0-9]+/g, ''), 10);
+
+    if (amountInt < incrementResults) {
+      return null;
+    }
 
     if (remainingResults <= 0) {
       return (
@@ -274,7 +287,7 @@ class Results extends React.Component {
     let resultsNumberSuggestion;
     // Converts the string of amount into integer
     // We need to remove the possible thousands separators first
-    const amountInt = parseInt(amount.replace(/,/g, ''), 10);
+    const amountInt = parseInt(amount.replace(/[^0-9]+/g, ''), 10);
     const textOfResult = amountInt === 1 ? 'result' : 'results';
     const resultMessageClass = (resultsLength === 0 || !isKeywordValid)
       ? 'noResultMessage' : `${className}-length`;
@@ -344,7 +357,7 @@ class Results extends React.Component {
     const inputValue = searchKeyword || '';
     // Converts the string of amount into integer
     // We need to remove the possible thousands separators first
-    const amountInt = parseInt(amount.replace(/,/g, ''), 10);
+    const amountInt = parseInt(amount.replace(/[^0-9]+/g, ''), 10);
 
     return (
       <div className={`${className}-wrapper`}>

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -272,7 +272,7 @@ class Results extends React.Component {
     } = this.state;
 
     let resultsNumberSuggestion;
-    // Converts the string of amount into interger
+    // Converts the string of amount into integer
     // We need to remove the possible thousands separators first
     const amountInt = parseInt(amount.replace(/,/g, ''), 10);
     const textOfResult = amountInt === 1 ? 'result' : 'results';
@@ -342,7 +342,7 @@ class Results extends React.Component {
 
     const results = this.getList(searchResults);
     const inputValue = searchKeyword || '';
-    // Converts the string of amount into interger
+    // Converts the string of amount into integer
     // We need to remove the possible thousands separators first
     const amountInt = parseInt(amount.replace(/,/g, ''), 10);
 

--- a/src/app/utils/SearchModel.js
+++ b/src/app/utils/SearchModel.js
@@ -19,7 +19,7 @@ const fetchResultLength = (data) => {
   try {
     const {
       searchInformation: {
-        formattedTotalResults: totalResults = 0,
+        formattedTotalResults: totalResults = '0',
       },
     } = data;
     return totalResults;

--- a/test/Results.test.js
+++ b/test/Results.test.js
@@ -214,7 +214,7 @@ describe('Results', () => {
     describe('if only 1 result is returned', () => {
       let component;
       const results = [{}];
-      const amount = results.length;
+      const amount = results.length.toString();
 
       before(() => {
         component = shallow(


### PR DESCRIPTION
This PR fixes the render of see more button. Currently on QA, if you go to https://qa-www.nypl.org/search/honey/  you won't see the see more button even it has 3,000ish results. However, on Prod you will. The reason is that when we try to convert the amount from a string, such as "3,000", to an integer by parseInt() it will stop by the thousand separator, so the converted integer is only 3 but 3000.

The PR adds the regular expression to remove all the thousand separators before running parseInt(). See line 227 and 347.

I think the function of rendering "see more button" can use some refactoring. But because we want to ship the current version out first, I will do it for the next sprint.