### PR TITLE
RENO-1275: update dgx-react-footer to 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.1.10
+#### Updated
+- Updating @nypl/dgx-react-footer to 0.5.6.
+
 ### v1.1.9
 #### Updated
 - Updating @nypl/dgx-react-footer to 0.5.5.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is the global search application for nypl.org.
 https://www.nypl.org/search
 
 ### Version
-> v1.1.9
+> v1.1.10
 
 ### Installation
 Install all dependencies listed under package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-global-search",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -238,6 +238,7 @@
         "axios": "0.9.1",
         "classnames": "2.1.3",
         "dgx-feature-flags": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#f7b1bd20f56632c71864cbe648556d03853d9f0e",
+        "dgx-react-ga": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#81c24190d40904e685fc6332a8bb518241680f08",
         "dgx-skip-navigation-link": "git+https://git@bitbucket.org/NYPL/dgx-skip-navigation-link.git#d1bdcf9e5d7d54fe252c6d8a250a42908fd98a87",
         "focus-trap-react": "3.0.3",
         "moment": "2.19.3",
@@ -260,8 +261,8 @@
           "integrity": "sha1-r5skU/wUOuhUbQ5zu+6kD3S342M="
         },
         "dgx-react-ga": {
-          "version": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#1908e78bd8704b815ec37030d0f8040f8b3cbb95",
-          "from": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#1908e78bd8704b815ec37030d0f8040f8b3cbb95",
+          "version": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#81c24190d40904e685fc6332a8bb518241680f08",
+          "from": "git+https://git@bitbucket.org/NYPL/dgx-react-ga.git#master",
           "requires": {
             "create-react-class": "15.5.3",
             "react-ga": "2.4.1"
@@ -275,18 +276,18 @@
       }
     },
     "@nypl/dgx-react-footer": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@nypl/dgx-react-footer/-/dgx-react-footer-0.5.5.tgz",
-      "integrity": "sha512-BOFwAcX2jvMviA/5FY1/wrH5Zfaqqkiy2hUwBsPLjQtHcpKakfmUlbJEb3CbxwsrzkpDYO4rcK9jxX0rVZtUQQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@nypl/dgx-react-footer/-/dgx-react-footer-0.5.6.tgz",
+      "integrity": "sha512-E/Nc93V3t1v4HSsFjpug6wtDWf7vlc/lpA3IdKDe5R14y2vrLXLaMX8NpQeet6f5qA2cEBZp9cWWpSCG1ZgW5A==",
       "requires": {
-        "@nypl/dgx-svg-icons": "0.3.11",
+        "@nypl/dgx-svg-icons": "0.3.12",
         "system-font-css": "^2.0.2"
       },
       "dependencies": {
         "@nypl/dgx-svg-icons": {
-          "version": "0.3.11",
-          "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.11.tgz",
-          "integrity": "sha512-DdL/kGqFEmvUM5WO6ETWv2H03ZjDH6/XV21WqTIG6FomkkdxEfTaJqFwHUkNRq+XxMOEDG/FIP+JPqthxy+msQ=="
+          "version": "0.3.12",
+          "resolved": "https://registry.npmjs.org/@nypl/dgx-svg-icons/-/dgx-svg-icons-0.3.12.tgz",
+          "integrity": "sha512-Co92hdOAL04STAKLa2JFQPdo/As3NDDVsPf1aiAfMPLzMKr4T8914V+0fMmLRZ7QL9xVOuCWU2vgo4pUgE0DxA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-global-search",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "DGX Global Search Repository",
   "main": "index.js",
   "scripts": {
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@nypl/dgx-header-component": "2.6.0",
-    "@nypl/dgx-react-footer": "0.5.5",
+    "@nypl/dgx-react-footer": "0.5.6",
     "@nypl/dgx-svg-icons": "0.3.9",
     "aws-sdk": "^2.382.0",
     "axios": "0.9.1",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1275)

**This PR does the following:**

- Updates dgx-react-footer to v0.5.6