### PR TITLE
RENO-1527 Fix caching errors

### DIFF
--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -61,7 +61,7 @@ const requestSearchResult = (req, res, next) => {
       next();
     })
     .catch((error) => {
-      logger.error(`error calling API : ${JSON.stringify(error, null, 2)}`);
+      logger.error(`error calling API from server : ${JSON.stringify(error, null, 2)}`);
       logger.error(`from the endpoint: ${searchApiUrl}`);
 
       res.locals.data = {
@@ -97,7 +97,7 @@ const requestResultsFromClient = (req, res) => {
       res.json(searchModeled);
     })
     .catch((error) => {
-      logger.error(`error calling API : ${JSON.stringify(error, null, 2)}`);
+      logger.error(`error calling API from client : ${JSON.stringify(error, null, 2)}`);
       logger.error(`from the endpoint: ${searchApiUrl}`);
     });
 };

--- a/src/server/ApiRoutes/cacheUtil.js
+++ b/src/server/ApiRoutes/cacheUtil.js
@@ -35,6 +35,9 @@ const checkForKeyInRedis = (client) => (key) => new Promise((resolve) => client
  */
 const getDataAndSetKeyInClient = (dataFunction, client) => (params, key) => dataFunction(...params)
   .then((response) => {
+    // Remove the 'request' object from the response added by axios. The included
+    // request object can cause circular reference errors.
+    delete response.request;
     const stringifiedResponse = JSON.stringify(response);
     // Note that this is asynchronous, but shouldn't matter in this simplest case
     client.set(key, stringifiedResponse, 'EX', 3600);


### PR DESCRIPTION
The updated version of axios includes the `request` object in its response which generates circular reference errors when parsing axios responses. This PR removes the `request` object from the `response` object to eliminate these errors so caching works as before.